### PR TITLE
Add github actions for basic CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,47 @@
+name: Test package
+
+on:
+    pull_request:
+        branches:
+              - master
+        paths:
+            - "**.py"
+    push:
+        branches:
+              - master
+        paths:
+            - "**.py"
+
+jobs:
+  build-os-latest:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 6
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        python-version: [3.6]
+        test-tool: [pylint, pytest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install test tool ${{ matrix.test-tool }}
+        run: |
+          pip install ${{ matrix.test-tool }}
+      - name: Run on pull_request
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+          changed_files="$(git diff --name-only origin/${{ github.base_ref }})"
+          ci/run-tests.sh --tests ${{ matrix.test-tool }} --files $changed_files
+      - name: Run on push
+        if: github.event_name == 'push'
+        run: |
+          ci/run-tests.sh --tests ${{ matrix.test-tool }}

--- a/ci/pylint-ignore
+++ b/ci/pylint-ignore
@@ -1,0 +1,5 @@
+# Legacy code
+symmetry_padding_3d.py
+
+# Don't pylint setup
+setup.py

--- a/tpcwithdnn/logger.py
+++ b/tpcwithdnn/logger.py
@@ -88,7 +88,7 @@ def configure_logger(debug, logfile=None):
         logger.setLevel(logging.INFO)
 
     sh = logging.StreamHandler()
-    formatter = LoggerFormatter(color=lambda : getattr(sh.stream, 'isatty', None)) # pylint: disable=C0326
+    formatter = LoggerFormatter(color=lambda : getattr(sh.stream, 'isatty', None)) # pylint: disable=bad-option-value
 
     sh.setFormatter(formatter)
     logger.addHandler(sh)


### PR DESCRIPTION
Include only pylint at the moment but easy to extend to include further
testing tools. pytest in principle already there, if exists, tests what
is found in ci/pytest

Locally, run

./ci/run-tests --tests pylint

to run pylint for all your python files. This does only include files
tracked by git.

As python 3.6 is required for installation at the moment only test with
that version.

Adjust pylint ignore in logger.py