### PR TITLE
Adjusted code to CUDA 11

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -86,7 +86,7 @@ then
             echo "Creating virtual environment"
             create-virtualenv --force
         fi
-        export LD_LIBRARY_PATH=/home/dsekihat/local/cuda/lib64/:$LD_LIBRARY_PATH;
+        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH;
         export FLUCTUATIONDIR="/data/tpcml/";
         activate-virtualenv
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-numpy
+numpy==1.18.5
 pandas
 matplotlib
 scipy==1.4.1
 keras==2.3.1
-tensorflow==2.1.0
 PyYaml
 RootInteractive
+tf-nightly-gpu==2.4.0.dev20200908; sys_platform == 'linux'
 pydot
 pylint

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
   # your project is installed. For an analysis of "install_requires" vs pip's
   # requirements files see:
   # https://packaging.python.org/en/latest/requirements.html
-  install_requires=[ "numpy", "pandas", "matplotlib", "scipy==1.4.1",
-                     "keras==2.3.1", "tensorflow==2.1.0", "PyYaml", "RootInteractive",
+  install_requires=[ "numpy==1.18.5", "pandas", "matplotlib", "scipy==1.4.1",
+                     "keras==2.3.1", "PyYaml", "RootInteractive", "tf-nightly-gpu==2.4.0.dev20200908",
                      "pydot", "pylint"],
 
   python_requires='>=3.6, <3.7',

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -4,7 +4,7 @@ import os
 import matplotlib
 import numpy as np
 import pandas as pd
-from keras.models import model_from_json
+from tensorflow.keras.models import model_from_json
 from root_pandas import to_root # pylint: disable=import-error, unused-import
 
 from tpcwithdnn.logger import get_logger

--- a/tpcwithdnn/dnn_optimiser.py
+++ b/tpcwithdnn/dnn_optimiser.py
@@ -7,10 +7,10 @@ import matplotlib.pyplot as plt
 
 import numpy as np
 
-from keras.callbacks import TensorBoard
-from keras.optimizers import Adam
-from keras.models import model_from_json
-from keras.utils.vis_utils import plot_model
+from tensorflow.keras.callbacks import TensorBoard
+from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.models import model_from_json
+from tensorflow.keras.utils import plot_model
 
 from root_numpy import fill_hist # pylint: disable=import-error
 
@@ -24,7 +24,6 @@ from tpcwithdnn.fluctuation_data_generator import FluctuationDataGenerator
 from tpcwithdnn.utilities_dnn import u_net
 from tpcwithdnn.data_loader import load_train_apply, get_event_mean_indices
 
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 matplotlib.use("Agg")
 
 class DnnOptimiser:
@@ -153,10 +152,10 @@ class DnnOptimiser:
         tensorboard_callback = TensorBoard(log_dir=log_dir, histogram_freq=1)
 
         model._get_distribution_strategy = lambda: None
-        his = model.fit_generator(generator=training_generator,
-                                  validation_data=validation_generator,
-                                  use_multiprocessing=True,
-                                  epochs=self.epochs, workers=1, callbacks=[tensorboard_callback])
+        his = model.fit(training_generator,
+                        validation_data=validation_generator,
+                        use_multiprocessing=False,
+                        epochs=self.epochs, callbacks=[tensorboard_callback])
 
         plt.style.use("ggplot")
         plt.figure()

--- a/tpcwithdnn/fluctuation_data_generator.py
+++ b/tpcwithdnn/fluctuation_data_generator.py
@@ -2,12 +2,12 @@
 # pylint: disable=missing-module-docstring, missing-class-docstring
 import numpy as np
 
-import keras
+import tensorflow.keras
 
 from tpcwithdnn.data_loader import load_train_apply
 
 #https://stanford.edu/~shervine/blog/keras-how-to-generate-data-on-the-fly
-class FluctuationDataGenerator(keras.utils.Sequence):
+class FluctuationDataGenerator(tensorflow.keras.utils.Sequence):
 
     def __init__(self, list_ids, phi_slice, r_row, z_col, batch_size, shuffle,
                  opt_train, opt_predout, selopt_input, selopt_output, data_dir,

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -2,7 +2,12 @@
 main script for doing tpc calibration with dnn
 """
 
+import os
 import yaml
+
+# Needs to be set before any tensorflow import to suppress logging
+# pylint: disable=wrong-import-position
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 import tpcwithdnn.check_root # pylint: disable=unused-import
 from tpcwithdnn.logger import get_logger

--- a/tpcwithdnn/symmetry_padding_3d.py
+++ b/tpcwithdnn/symmetry_padding_3d.py
@@ -1,7 +1,7 @@
-# pylint: disable=missing-module-docstring, missing-class-docstring
-import keras.backend as K
-from keras.layers import Layer
+# pylint: disable=missing-module-docstring, missing-class-docstring, fixme
 import tensorflow as tf
+# import keras.backend as K
+from tensorflow.keras.layers import Layer
 
 class SymmetryPadding3d(Layer):
     def __init__(self, padding=None,
@@ -9,19 +9,20 @@ class SymmetryPadding3d(Layer):
         self.data_format = data_format
         self.padding = [[0, 0], [1, 1], [1, 1], [1, 1], [0, 0]] if padding is None else padding
         self.mode = mode
-        super(SymmetryPadding3d, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.output_dim = None
 
     # pylint: disable=arguments-differ
     def call(self, inputs):
         pad = [[0, 0]] + self.padding + [[0, 0]]
-        if K.backend() == "tensorflow":
-            paddings = tf.constant(pad)
-            #print(inputs.shape)
-            #print(paddings)
-            out = tf.pad(inputs, paddings, self.mode)
-        else:
-            raise Exception("Backend " + K.backend() + "not implemented")
+        # TODO: Do we expect other backends as well?
+        # if K.backend() == "tensorflow":
+        paddings = tf.constant(pad)
+        #print(inputs.shape)
+        #print(paddings)
+        out = tf.pad(inputs, paddings, self.mode)
+        # else:
+        #    raise Exception("Backend " + K.backend() + "not implemented")
         self.output_dim = [(out.shape[0], out.shape[1], out.shape[2], out.shape[3], out.shape[4])]
         return out
 
@@ -30,5 +31,5 @@ class SymmetryPadding3d(Layer):
 
     def get_config(self):
         config = {'padding': self.padding, 'data_format': self.data_format, 'mode': self.mode}
-        base_config = super(SymmetryPadding3d, self).get_config()
+        base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/tpcwithdnn/utilities_dnn.py
+++ b/tpcwithdnn/utilities_dnn.py
@@ -1,11 +1,11 @@
 # pylint: disable=too-many-arguments, invalid-name
 # pylint: disable=missing-module-docstring, missing-function-docstring
-from keras.models import Model
-from keras.layers import Input, concatenate, UpSampling3D
-from keras.layers import AveragePooling3D, Conv3DTranspose
-from keras.layers.core import Dropout
-from keras.layers.normalization import BatchNormalization
-from keras.layers.convolutional import Conv3D, MaxPooling3D
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Input, concatenate, UpSampling3D
+from tensorflow.keras.layers import AveragePooling3D, Conv3DTranspose
+from tensorflow.keras.layers import Dropout
+from tensorflow.keras.layers import BatchNormalization
+from tensorflow.keras.layers import Conv3D, MaxPooling3D
 
 from tpcwithdnn.symmetry_padding_3d import SymmetryPadding3d
 


### PR DESCRIPTION
Ciao @ginnocen , @harisriaz17, @benedikt-voelkel 

With these adjustments I am able to run TPC ML code properly. Let me know your opinion, esp. with respect to using tf-nightly-gpu instead of tensorflow release.

Main changes:
- tensorflow --> tf-nightly-gpu package that support CUDA 11
- tf-nightly-gpu in turn requires older numpy and changing keras --> tensorflow.keras
- fitting with multiprocessing=False, otherwise tf prints deadlock warnings and ignores workers=1 setting. Does not seem to affect performance as we had workers=1 anyways.