### PR TITLE
Changed fluctuations to random-mean instead of mean-random

### DIFF
--- a/tpcwithdnn/data_loader.py
+++ b/tpcwithdnn/data_loader.py
@@ -93,12 +93,12 @@ def load_data(input_data, event_index, selopt_input, selopt_output):
 
     if selopt_input == 0:
         vec_mean_sc = vec_mean_sc[vec_z_pos >= 0]
-        vec_fluctuation_sc = vec_mean_sc - vec_random_sc[vec_z_pos >= 0]
+        vec_fluctuation_sc = vec_random_sc[vec_z_pos >= 0] - vec_mean_sc
     elif selopt_input == 1:
         vec_mean_sc = vec_mean_sc[vec_z_pos < 0]
-        vec_fluctuation_sc = vec_mean_sc - vec_random_sc[vec_z_pos < 0]
+        vec_fluctuation_sc = vec_random_sc[vec_z_pos < 0] - vec_mean_sc
     elif selopt_input == 2:
-        vec_fluctuation_sc = vec_mean_sc - vec_random_sc
+        vec_fluctuation_sc = vec_random_sc - vec_mean_sc
 
     # selopt_output == 0 selects only clusters with positive z position
     # selopt_output == 1 selects only clusters with negative z position
@@ -106,22 +106,22 @@ def load_data(input_data, event_index, selopt_input, selopt_output):
 
     if selopt_output == 0:
         vec_fluctuation_dist_r = \
-                vec_mean_dist_r[vec_z_pos >= 0] - vec_random_dist_r[vec_z_pos >= 0]
+                vec_random_dist_r[vec_z_pos >= 0] - vec_mean_dist_r[vec_z_pos >= 0]
         vec_fluctuation_dist_rphi = \
-                vec_mean_dist_rphi[vec_z_pos >= 0] - vec_random_dist_rphi[vec_z_pos >= 0]
+                vec_random_dist_rphi[vec_z_pos >= 0] - vec_mean_dist_rphi[vec_z_pos >= 0]
         vec_fluctuation_dist_z = \
-                vec_mean_dist_z[vec_z_pos >= 0] - vec_random_dist_z[vec_z_pos >= 0]
+                vec_random_dist_z[vec_z_pos >= 0] - vec_mean_dist_z[vec_z_pos >= 0]
     elif selopt_output == 1:
         vec_fluctuation_dist_r = \
-                vec_mean_dist_r[vec_z_pos < 0] - vec_random_dist_r[vec_z_pos < 0]
+                vec_random_dist_r[vec_z_pos < 0] - vec_mean_dist_r[vec_z_pos < 0]
         vec_fluctuation_dist_rphi = \
-                vec_mean_dist_rphi[vec_z_pos < 0] - vec_random_dist_rphi[vec_z_pos < 0]
+                vec_random_dist_rphi[vec_z_pos < 0] - vec_mean_dist_rphi[vec_z_pos < 0]
         vec_fluctuation_dist_z = \
-                vec_mean_dist_z[vec_z_pos < 0] - vec_random_dist_z[vec_z_pos < 0]
+                vec_random_dist_z[vec_z_pos < 0] - vec_mean_dist_z[vec_z_pos < 0]
     elif selopt_output == 2:
-        vec_fluctuation_dist_r = vec_mean_dist_r - vec_random_dist_r
-        vec_fluctuation_dist_rphi = vec_mean_dist_rphi - vec_random_dist_rphi
-        vec_fluctuation_dist_z = vec_mean_dist_z - vec_random_dist_z
+        vec_fluctuation_dist_r = vec_random_dist_r - vec_mean_dist_r
+        vec_fluctuation_dist_rphi = vec_random_dist_rphi - vec_mean_dist_rphi
+        vec_fluctuation_dist_z = vec_random_dist_z - vec_mean_dist_z
 
     return [vec_mean_sc, vec_fluctuation_sc, vec_fluctuation_dist_r,
             vec_fluctuation_dist_rphi, vec_fluctuation_dist_z]

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -142,7 +142,7 @@ class DataValidator:
 
         mat_mean_dist = np.array((vec_mean_dist_r, vec_mean_dist_rphi, vec_mean_dist_z))
         mat_rand_dist = np.array((vec_rand_dist_r, vec_rand_dist_rphi, vec_rand_dist_z))
-        mat_fluc_dist = mat_random_dist - mat_mean_dist
+        mat_fluc_dist = mat_rand_dist - mat_mean_dist
 
         vec_index_random = np.empty(vec_z_pos.size)
         vec_index_random[:] = irnd

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -142,7 +142,7 @@ class DataValidator:
 
         mat_mean_dist = np.array((vec_mean_dist_r, vec_mean_dist_rphi, vec_mean_dist_z))
         mat_rand_dist = np.array((vec_rand_dist_r, vec_rand_dist_rphi, vec_rand_dist_z))
-        mat_fluc_dist = mat_mean_dist - mat_rand_dist
+        mat_fluc_dist = mat_random_dist - mat_mean_dist
 
         vec_index_random = np.empty(vec_z_pos.size)
         vec_index_random[:] = irnd
@@ -150,7 +150,7 @@ class DataValidator:
         vec_index_mean[:] = imean
         vec_index = np.empty(vec_z_pos.size)
         vec_index[:] = irnd + 1000 * imean
-        vec_fluc_sc = vec_mean_sc - vec_random_sc
+        vec_fluc_sc = vec_random_sc - vec_mean_sc
         vec_delta_sc = np.empty(vec_z_pos.size)
         vec_delta_sc[:] = sum(vec_fluc_sc) / sum(vec_mean_sc)
 


### PR DESCRIPTION
Changing the fluctuation definitions from random-mean to mean-random, to agree with TPC convention.

The output plots w.r.t. fluctuations are mirrored but there is no other impact. 