### PR TITLE
Moving from root_pandas to uproot3 and RootInteractive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ psutil
 notebook
 torch
 xgboost
+uproot3

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
   # https://packaging.python.org/en/latest/requirements.html
   install_requires=[ "numpy==1.19.2", "pandas", "matplotlib", "scipy==1.4.1", "h5py<3.0.0",
                      "keras==2.3.1", "PyYaml", "RootInteractive", "tensorflow>=2.4",
-                     "pydot", "pylint", "psutil", "notebook", "torch", "xgboost"],
+                     "pydot", "pylint", "psutil", "notebook", "torch", "xgboost", "uproot3"],
 
   python_requires='>=3.6',
 

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -325,14 +325,14 @@ class DataValidator:
             input_file_name_0 = "%s/%s/pdfmap_flucSC_mean%.1f_nEv%d.root" \
                 % (self.config.diroutflattree, self.config.suffix, mean_factor,
                    self.config.train_events)
-            df = tree_to_pandas(input_file_name_0, 'flucSC', [".*Bin"])
+            df = tree_to_pandas(input_file_name_0, 'flucSC', "*Bin*")
             df['fsector'] = df['phiBinCenter'] / math.pi * 9
             df['meanMap'] = mean_factor
             for var in self.get_pdf_map_variables_list():
                 input_file_name = "%s/%s/pdfmap_%s_mean%.1f_nEv%d.root" \
                     % (self.config.diroutflattree, self.config.suffix, var, mean_factor,
                        self.config.train_events)
-                df_temp = tree_to_pandas(input_file_name, var, [".*"], [".*Bin"])
+                df_temp = tree_to_pandas(input_file_name, var, "*", ".*Bin")
                 for col in list(df_temp.keys()):
                     df[var + '_' + col] = df_temp[col]
             df_merged = df_merged.append(df, ignore_index=True)

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -1,21 +1,24 @@
 # pylint: disable=missing-module-docstring, missing-function-docstring, missing-class-docstring
 # pylint: disable=too-many-statements
 import os
+import shutil
 import gzip
 import pickle
 import math
 import numpy as np
 import pandas as pd
-from root_pandas import to_root, read_root  # pylint: disable=import-error, unused-import
 from RootInteractive.Tools.histoNDTools import makeHistogram  # pylint: disable=import-error, unused-import
 from RootInteractive.Tools.makePDFMaps import makePdfMaps  # pylint: disable=import-error, unused-import
 
 from tpcwithdnn.logger import get_logger
+from tpcwithdnn.utilities import pandas_to_tree, tree_to_pandas
 from tpcwithdnn.data_loader import load_data_original
 from tpcwithdnn.data_loader import load_data_derivatives_ref_mean
 
 class DataValidator:
     name = "data validator"
+    mean_ids = (0, 9, 18)
+    mean_factors = (1.0, 1.1, 0.9)
 
     def __init__(self):
         logger = get_logger()
@@ -27,14 +30,15 @@ class DataValidator:
         self.model = model
         self.config = model.config
 
-    def create_data_for_event(self, imean, irnd, column_names, vec_der_ref_mean_sc,
-                              mat_der_ref_mean_dist, loaded_model, tree_filename):
+    def create_data_for_event(self, index_mean_id, irnd, column_names, vec_der_ref_mean_sc,
+                              mat_der_ref_mean_dist, loaded_model, dir_name):
         [vec_r_pos, vec_phi_pos, vec_z_pos,
          vec_mean_sc, vec_random_sc,
          vec_mean_dist_r, vec_rand_dist_r,
          vec_mean_dist_rphi, vec_rand_dist_rphi,
-         vec_mean_dist_z, vec_rand_dist_z] = load_data_original(self.config.dirinput_val,
-                                                                [irnd, imean])
+         vec_mean_dist_z, vec_rand_dist_z] = load_data_original(
+             self.config.dirinput_val,
+            [irnd, self.mean_ids[index_mean_id]])
 
         vec_sel_z = (self.config.input_z_range[0] <= vec_z_pos) &\
                     (vec_z_pos < self.config.input_z_range[1])
@@ -57,9 +61,9 @@ class DataValidator:
         vec_index_random = np.empty(vec_z_pos.size)
         vec_index_random[:] = irnd
         vec_index_mean = np.empty(vec_z_pos.size)
-        vec_index_mean[:] = imean
+        vec_index_mean[:] = self.mean_ids[index_mean_id]
         vec_index = np.empty(vec_z_pos.size)
-        vec_index[:] = irnd + 1000 * imean
+        vec_index[:] = irnd + 1000 * self.mean_ids[index_mean_id]
         vec_fluc_sc = vec_random_sc - vec_mean_sc
         vec_delta_sc = np.empty(vec_z_pos.size)
         vec_delta_sc[:] = sum(vec_fluc_sc) / sum(vec_mean_sc)
@@ -103,7 +107,17 @@ class DataValidator:
                 df_single_map[column_names[19 + ind_dist]] = \
                     mat_fluc_dist_predict[ind_dist, :]
 
-        df_single_map.to_root(tree_filename, key="validation", mode="a", store_index=False)
+        tree_filename = "%s/%d/treeInput_mean%.2f_%s.root" \
+            % (dir_name, irnd, self.mean_factors[index_mean_id], self.config.suffix_ds)
+        if self.config.validate_model:
+            tree_filename = "%s/%d/treeValidation_mean%.2f_nEv%d.root" \
+                            % (dir_name, irnd, self.mean_factors[index_mean_id],
+                               self.config.train_events)
+
+        if not os.path.isdir("%s/%d" % (dir_name, irnd)):
+            os.makedirs("%s/%d" % (dir_name, irnd))
+
+        pandas_to_tree(df_single_map, tree_filename, 'validation')
 
     # pylint: disable=too-many-locals, too-many-branches
     def create_data(self):
@@ -126,39 +140,39 @@ class DataValidator:
         else:
             loaded_model = None
 
-        for imean, mean_factor in zip([0, 9, 18], [1.0, 1.1, 0.9]):
-            tree_filename = "%s/treeInput_mean%.1f_%s.root" \
-                            % (self.config.diroutflattree, mean_factor, self.config.suffix_ds)
-            if self.config.validate_model:
-                tree_filename = "%s/%s/treeValidation_mean%.1f_nEv%d.root" \
-                                % (self.config.diroutflattree, self.config.suffix, mean_factor,
-                                   self.config.train_events)
+        dir_name = "%s/parts" % (self.config.diroutflattree)
+        if self.config.validate_model:
+            dir_name = "%s/%s/parts" % (self.config.diroutflattree, self.config.suffix)
+        if os.path.isdir(dir_name):
+            shutil.rmtree(dir_name)
 
-            if os.path.isfile(tree_filename):
-                os.remove(tree_filename)
-
+        for index_mean_id in range(0, len(self.mean_ids)):
             counter = 0
             if self.config.use_partition != 'random':
                 for ind_ev in self.config.part_inds:
-                    if ind_ev[1] != imean:
+                    if ind_ev[1] != self.mean_ids[index_mean_id]:
                         continue
                     irnd = ind_ev[0]
-                    self.config.logger.info("processing event: %d [%d, %d]", counter, imean, irnd)
-                    self.create_data_for_event(imean, irnd, column_names, vec_der_ref_mean_sc,
-                                               mat_der_ref_mean_dist, loaded_model, tree_filename)
+                    self.config.logger.info("processing event: %d [%d, %d]",
+                                            counter, self.mean_ids[index_mean_id], irnd)
+                    self.create_data_for_event(index_mean_id, irnd, column_names,
+                                               vec_der_ref_mean_sc, mat_der_ref_mean_dist,
+                                               loaded_model, dir_name)
                     counter = counter + 1
                     if counter == self.config.val_events:
                         break
             else:
                 for irnd in range(self.config.maxrandomfiles):
-                    self.config.logger.info("processing event: %d [%d, %d]", counter, imean, irnd)
-                    self.create_data_for_event(imean, irnd, column_names, vec_der_ref_mean_sc,
-                                               mat_der_ref_mean_dist, loaded_model, tree_filename)
+                    self.config.logger.info("processing event: %d [%d, %d]",
+                                            counter, self.mean_ids[index_mean_id], irnd)
+                    self.create_data_for_event(index_mean_id, irnd, column_names,
+                                               vec_der_ref_mean_sc, mat_der_ref_mean_dist,
+                                               loaded_model, dir_name)
                     counter = counter + 1
                     if counter == self.config.val_events:
                         break
 
-            self.config.logger.info("Tree written in %s", tree_filename)
+            self.config.logger.info("Trees written in %s", dir_name)
 
 
     def get_pdf_map_variables_list(self):
@@ -197,10 +211,10 @@ class DataValidator:
         else:
             column_names = column_names + [var[:diff_index], var[:diff_index] + "Pred"]
 
-        df_val = read_root("%s/%s/treeValidation_mean%.1f_nEv%d.root"
-                           % (self.config.diroutflattree, self.config.suffix, mean_factor,
-                              self.config.train_events),
-                           key='validation', columns=column_names)
+        df_val = tree_to_pandas("%s/%s/treeValidation_mean%.1f_nEv%d.root"
+                                % (self.config.diroutflattree, self.config.suffix, mean_factor,
+                                   self.config.train_events),
+                                'validation', column_names)
         if diff_index != -1:
             df_val[var] = \
                 df_val[var[:diff_index] + "Pred"] - df_val[var[:diff_index]]
@@ -274,9 +288,7 @@ class DataValidator:
                   (0, histo['H'].shape[3], 1, 0),
                   (0, histo['H'].shape[4], 1, 0))
         df_pdf_map = makePdfMaps(histo, slices, dim_var)
-        # set the index name to retrieve the name of the variable of interest later
-        df_pdf_map.index.name = histo['name']
-        df_pdf_map.to_root(output_file_name, key=histo['name'], mode='w', store_index=True)
+        pandas_to_tree(df_pdf_map, output_file_name, histo['name'])
         self.config.logger.info("Pdf map %s written to %s.", histo['name'], output_file_name)
 
 
@@ -313,21 +325,21 @@ class DataValidator:
             input_file_name_0 = "%s/%s/pdfmap_flucSC_mean%.1f_nEv%d.root" \
                 % (self.config.diroutflattree, self.config.suffix, mean_factor,
                    self.config.train_events)
-            df = read_root(input_file_name_0, columns="*Bin*")
+            df = tree_to_pandas(input_file_name_0, 'flucSC', [".*Bin"])
             df['fsector'] = df['phiBinCenter'] / math.pi * 9
             df['meanMap'] = mean_factor
             for var in self.get_pdf_map_variables_list():
                 input_file_name = "%s/%s/pdfmap_%s_mean%.1f_nEv%d.root" \
                     % (self.config.diroutflattree, self.config.suffix, var, mean_factor,
                        self.config.train_events)
-                df_temp = read_root(input_file_name, ignore="*Bin*")
+                df_temp = tree_to_pandas(input_file_name, var, [".*"], [".*Bin"])
                 for col in list(df_temp.keys()):
                     df[var + '_' + col] = df_temp[col]
             df_merged = df_merged.append(df, ignore_index=True)
 
         output_file_name = "%s/%s/pdfmaps_nEv%d.root" \
             % (self.config.diroutflattree, self.config.suffix, self.config.train_events)
-        df_merged.to_root(output_file_name, key='pdfmaps', mode='w', store_index=False)
+        pandas_to_tree(df_merged, output_file_name, 'pdfmaps')
         self.config.logger.info("Pdf maps written to %s.", output_file_name)
 
     def merge_pdf_maps_meanid(self, mean_id):

--- a/tpcwithdnn/idc_data_validator.py
+++ b/tpcwithdnn/idc_data_validator.py
@@ -12,8 +12,8 @@ from RootInteractive.Tools.makePDFMaps import makePdfMaps  # pylint: disable=imp
 
 from tpcwithdnn.logger import get_logger
 from tpcwithdnn.utilities import pandas_to_tree, tree_to_pandas
-from tpcwithdnn.data_loader import load_data_original_idc
-from tpcwithdnn.data_loader import filter_idc_data, mat_to_vec, get_fourier_coefs
+from tpcwithdnn.data_loader import load_data_original_idc, get_input_oned_idc_single_map
+from tpcwithdnn.data_loader import filter_idc_data, mat_to_vec, get_fourier_coeffs
 from tpcwithdnn.data_loader import load_data_derivatives_ref_mean_idc
 
 class IDCDataValidator():
@@ -139,14 +139,9 @@ class IDCDataValidator():
         if self.config.validate_model:
             fluc_zero_idc = random_zero_idc - mean_zero_idc
             vec_der_ref_mean_corr,  = mat_to_vec(self.config.opt_predout, (mat_der_ref_mean_corr,))
-            dft_coefs = get_fourier_coefs(fluc_one_idc)
-            inputs = np.zeros((vec_der_ref_mean_corr.size,
-                               4 + dft_coefs.size + fluc_zero_idc.size))
-            for ind, pos in enumerate((vec_r_pos, vec_phi_pos, vec_z_pos)):
-                inputs[:, ind] = pos
-            inputs[:, 3] = vec_der_ref_mean_corr
-            inputs[:, 4:4+fluc_zero_idc.size] = fluc_zero_idc
-            inputs[:, -dft_coefs.size:] = dft_coefs # pylint: disable=invalid-unary-operand-type
+            dft_coeffs = get_fourier_coeffs(fluc_one_idc)
+            inputs = get_input_oned_idc_single_map(vec_r_pos, vec_phi_pos, vec_z_pos,
+                                                   vec_der_ref_mean_corr, fluc_zero_idc, dft_coeffs)
             df_single_map[column_names[30]] = loaded_model.predict(inputs)
 
         tree_filename = "%s/%d/treeInput_mean%.2f_%s.root" \
@@ -366,14 +361,14 @@ class IDCDataValidator():
             input_file_name_0 = "%s/%s/pdfmap_flucSC_mean%.1f_nEv%d.root" \
                 % (self.config.diroutflattree, self.config.suffix, mean_factor,
                    self.config.train_events)
-            df = tree_to_pandas(input_file_name_0, 'flucSC', [".*Bin"])
+            df = tree_to_pandas(input_file_name_0, 'flucSC', "*Bin*")
             df['fsector'] = df['phiBinCenter'] / math.pi * 9
             df['meanMap'] = mean_factor
             for var in self.get_pdf_map_variables_list():
                 input_file_name = "%s/%s/pdfmap_%s_mean%.1f_nEv%d.root" \
                     % (self.config.diroutflattree, self.config.suffix, var, mean_factor,
                        self.config.train_events)
-                df_temp = tree_to_pandas(input_file_name, var, [".*"], [".*Bin"])
+                df_temp = tree_to_pandas(input_file_name, var, "*", ".*Bin")
                 for col in list(df_temp.keys()):
                     df[var + '_' + col] = df_temp[col]
             df_merged = df_merged.append(df, ignore_index=True)

--- a/tpcwithdnn/merge_validation_trees.sh
+++ b/tpcwithdnn/merge_validation_trees.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+[[ $# -lt 1 ]] && cat <<HELP_USAGE
+    merge_validation_trees.sh - merge input or validation trees created using "docreatevaldata true" in default.yml (function create_data() in tpcwithdnn/data_validator.py or tpcwithdnn/idc_data_validator.py)
+
+    Input:
+        Param 1: inputDir - path to output trees, usually <base_dir>/trees (input data trees) or <base_dir>/trees/<model_parameters> (validation data trees)
+        Param 2 optional: nTrainEvents - number of training events used for model of validation tree
+    Example usage:
+         ./merge_validation_trees.sh trees
+         ./merge_validation_trees.sh trees 5000
+HELP_USAGE
+[[ $# -lt 1 ]] && exit
+
+inputDir=$1
+
+# case for second argument (nTrainEvents) provided
+if [ $# -eq 2 ]; then
+  nTrainEvents=$2
+  [[ -z $(ls $(ls -d ${inputDir}/parts/* | head -n 1) | grep "_nEv${nTrainEvents}.root") ]] && echo "No files exist for number of training events specified in arguments!" && exit
+  for ifile in $(ls $(ls -d ${inputDir}/parts/* | head -n 1) | grep nEv${nTrainEvents}); do
+    hadd -f ${inputDir}/${ifile} $(ls ${inputDir}/parts/*/${ifile})
+  done
+  exit
+fi
+
+# case for one argument (inputDir) provided
+for ifile in $(ls $(ls -d ${inputDir}/parts/* | head -n 1)); do
+  hadd -f ${inputDir}/${ifile} $(ls ${inputDir}/parts/*/${ifile})
+done

--- a/tpcwithdnn/utilities.py
+++ b/tpcwithdnn/utilities.py
@@ -1,4 +1,5 @@
 # pylint: disable=pointless-string-statement
+import re
 import pandas as pd
 import uproot3
 from RootInteractive.Tools.aliTreePlayer import LoadTrees, tree2Panda
@@ -24,7 +25,7 @@ def pandas_to_tree(data, file_name, tree_name):
                                        for i in range(0, len(data.columns))})
 
 
-def tree_to_pandas(file_name, tree_name, columns, exclude_columns=[]):  # pylint: disable=dangerous-default-value
+def tree_to_pandas_ri(file_name, tree_name, columns, exclude_columns=[]):  # pylint: disable=dangerous-default-value
     """
         Parameters
         ----------
@@ -68,4 +69,31 @@ def tree_to_pandas(file_name, tree_name, columns, exclude_columns=[]):  # pylint
         data = pd.concat([data, df_tmp], ignore_index=True)
         first_entry = first_entry + max_rows_pandas - 1
 
+    return data
+
+
+def tree_to_pandas(file_name, tree_name, columns, exclude_columns=""):  # pylint: disable=dangerous-default-value
+    """
+        Parameters
+        ----------
+        file_name : str
+            Path to root file
+        tree_name : str
+            Name of TTree
+        columns: sequence of str
+            Names of branches or aliases to be read. Can also use wildcards like ["*"]
+            for all branches or ["*fluc*"] for all branches containing the string "fluc".
+        exclude_columns: str
+            Regular expression of columns to be ignored, e.g. ".*Id".
+
+        Returns
+        --------
+        pandas.DataFrame
+            Data frame with specified columns
+    """
+    with uproot3.open(file_name) as file:
+        data = file[tree_name].pandas.df(columns)
+    if exclude_columns != "":
+        data = data.filter([col for col in data.columns
+                            if not re.compile(exclude_columns).match(col)])
     return data

--- a/tpcwithdnn/utilities.py
+++ b/tpcwithdnn/utilities.py
@@ -1,0 +1,71 @@
+# pylint: disable=pointless-string-statement
+import pandas as pd
+import uproot3
+from RootInteractive.Tools.aliTreePlayer import LoadTrees, tree2Panda
+
+
+def pandas_to_tree(data, file_name, tree_name):
+    """
+      Parameters
+      ----------
+      data : pandas.DataFrame
+          Data frame which should be stored as TTree
+      file_name : str
+          Path and name of root file
+      tree_name : str
+          Name of TTree
+    """
+    branch_dict = {data.columns[i]: data.dtypes[i]
+                   for i in range(0, len(data.columns))}
+    with uproot3.recreate(file_name) as file_output:
+        file_output[tree_name] = uproot3.newtree(branch_dict)
+        file_output[tree_name].extend({data.columns[i]:
+                                       data[data.columns[i]].to_numpy()
+                                       for i in range(0, len(data.columns))})
+
+
+def tree_to_pandas(file_name, tree_name, columns, exclude_columns=[]):  # pylint: disable=dangerous-default-value
+    """
+        Parameters
+        ----------
+        file_name : str
+            Path to root file
+        tree_name : str
+            Name of TTree
+        columns: sequence of str
+            Names of branches or aliases to be read. Can also be regular expression like ['.*']
+            for all branches or ['.*fluc'] for all branches containing the string "fluc".
+        exclude_columns: sequence of str, optional
+            Names of branches or aliases to be ignored. Can also be regular expression like
+            ['.*fluc'] for all branches containing the string "fluc".
+
+        Returns
+        --------
+        pandas.DataFrame
+            Data frame with specified columns
+    """
+    # The tree2panda function only works if the returned df has less than 1M rows.
+    # For entries at rows > 1M the data is corrupt. RootInteractive developers are aware.
+    max_rows_pandas = 1000000
+
+    tree, _, _ = LoadTrees("ls %s" % file_name, tree_name, "xxx", "", 0)
+    """
+    LoadTrees()
+    Param 1: shell command to obtain file names, e.g. ls file.root or cat files.list
+    Param 2: input trees to be selected
+    Param 3: input tree not to be selected
+    Param 4: if not empty, files from first argument to be used
+    Param 5: verbosity level
+    """
+
+    data = pd.DataFrame()
+    n_entries = tree.GetEntries()
+    first_entry = 0
+    exclude_columns.append("%s*" % tree_name)
+    while first_entry < n_entries:
+        df_tmp = tree2Panda(tree, columns, "", exclude=exclude_columns,
+                            nEntries=max_rows_pandas - 1, firstEntry=first_entry)
+        data = pd.concat([data, df_tmp], ignore_index=True)
+        first_entry = first_entry + max_rows_pandas - 1
+
+    return data


### PR DESCRIPTION
I exchanged all root_pandas functions (except in jupyter notebooks) with corresponding functionality of uproot3 (pandas->TTree) and RootInteractive (TTree->pandas). Helper functions in tpcwithdnn/utilities.py are used for this. 

For the data validators, data frames for single maps are now written to single files in the directory trees/parts or trees/<model_params>/parts instead of updating the merged file because no update functionality is available in uproot. The merging is now done manually using the script tpcwithdnn/merge_validation_trees.sh, providing the input directory to the parts folder.

Creating input and validation trees was tested successfully. Creating nd histograms and pdf maps *still have to be tested*. I will do this in following studies.