### PR TITLE
Option to cache training data

### DIFF
--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -1,7 +1,7 @@
 """
 User settings from the config_model_parameters.yml
 """
-# pylint: disable=too-many-instance-attributes, too-few-public-methods
+# pylint: disable=too-many-instance-attributes, too-few-public-methods, unused-private-member
 import os
 
 import numpy as np
@@ -108,7 +108,7 @@ class CommonSettings:
         self.val_events = 0
         self.apply_events = 0
 
-    def set_ranges_(self, ranges, suffix, total_events, train_events, val_events, apply_events):
+    def __set_ranges(self, ranges, suffix, total_events, train_events, val_events, apply_events):
         """
         Update the event indices ranges for train / validation / apply.
         To be used internally.
@@ -222,7 +222,7 @@ class DNNSettings:
 
     def set_ranges(self, ranges, total_events, train_events, val_events, apply_events):
         """
-        A wrapper around internal set_ranges_().
+        A wrapper around internal set_ranges().
 
         :param dict ranges: dictionary of lists of event indices ranges for train/validation/apply
         :param int total_events: number of all events used
@@ -230,7 +230,8 @@ class DNNSettings:
         :param int val_events: number of events used for validation
         :param int apply_events: number of events used for prediction
         """
-        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events)
+        self._CommonSettings__set_ranges(ranges, self.suffix, total_events, train_events,
+                                         val_events, apply_events)
 
 class XGBoostSettings:
     name = "xgboost"
@@ -311,7 +312,7 @@ class XGBoostSettings:
 
     def set_ranges(self, ranges, total_events, train_events, val_events, apply_events):
         """
-        A wrapper around internal set_ranges_().
+        A wrapper around internal set_ranges().
 
         :param dict ranges: dictionary of lists of event indices ranges for train/validation/apply
         :param int total_events: number of all events used
@@ -319,4 +320,14 @@ class XGBoostSettings:
         :param int val_events: number of events used for validation
         :param int apply_events: number of events used for prediction
         """
-        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events)
+        self._CommonSettings__set_ranges(ranges, self.suffix, total_events, train_events,
+                                         val_events, apply_events)
+
+    def set_cache_ranges(self):
+        """
+        Set ranges for caching.
+        """
+        ranges = {"train": [0, self.cache_events],
+                  "validation": [self.cache_events, self.cache_events],
+                  "apply": [self.cache_events, self.cache_events]}
+        self.set_ranges(ranges, self.cache_events, self.cache_events, 0, 0)

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -63,8 +63,6 @@ class CommonSettings:
         self.logger.info("Inputs active for training: (SCMean, SCFluctuations)=(%d, %d)",
                          self.opt_train[0], self.opt_train[1])
 
-        self.nd_validate_model = data_param["nd_validate_model"]
-
         # Directories
         self.dirmodel = data_param["dirmodel"]
         self.dirapply = data_param["dirapply"]

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -71,7 +71,6 @@ class CommonSettings:
         self.dirplots = data_param["dirplots"]
         self.dirtree = data_param["dirtree"]
         self.dirhist = data_param["dirhist"]
-        self.dirinput_cache = data_param["dirinput_cache"]
         train_dir = data_param["dirinput_bias"] if data_param["train_bias"] \
                     else data_param["dirinput_nobias"]
         val_dir = data_param["dirinput_bias"] if data_param["validation_bias"] \
@@ -87,8 +86,7 @@ class CommonSettings:
         self.dirinput_nd_val = "%s/SC-%d-%d-%d" % (data_param["dirinput_nobias"],
                                self.grid_z, self.grid_r, self.grid_phi)
 
-        for dirname in (self.dirmodel, self.dirapply, self.dirplots, self.dirtree, self.dirhist,
-                        self.dirinput_cache):
+        for dirname in (self.dirmodel, self.dirapply, self.dirplots, self.dirtree, self.dirhist):
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
 
@@ -111,10 +109,8 @@ class CommonSettings:
         self.train_events = 0
         self.val_events = 0
         self.apply_events = 0
-        self.cache_events = 0
 
-    def set_ranges_(self, ranges, suffix, total_events, train_events, val_events, apply_events,
-                    cache_events):
+    def set_ranges_(self, ranges, suffix, total_events, train_events, val_events, apply_events):
         """
         Update the event indices ranges for train / validation / apply.
         To be used internally.
@@ -125,14 +121,11 @@ class CommonSettings:
         :param int train_events: number of events used for training
         :param int val_events: number of events used for validation
         :param int apply_events: number of events used for prediction
-        :param int cache_events: number of events to dump (cache) for future training
-                                 valid only for XGBoost
         """
         self.total_events = total_events
         self.train_events = train_events
         self.val_events = val_events
         self.apply_events = apply_events
-        self.cache_events = cache_events
 
         self.indices_events_means, self.partition = get_event_mean_indices(
             self.range_rnd_index_train, self.range_mean_index, ranges, self.rnd_augment)
@@ -229,8 +222,7 @@ class DNNSettings:
         except AttributeError as attr_err:
             raise AttributeError("'DNNSettings' object has no attribute '%s'" % name) from attr_err
 
-    def set_ranges(self, ranges, total_events, train_events, val_events, apply_events,
-                   cache_events):
+    def set_ranges(self, ranges, total_events, train_events, val_events, apply_events):
         """
         A wrapper around internal set_ranges_().
 
@@ -239,11 +231,8 @@ class DNNSettings:
         :param int train_events: number of events used for training
         :param int val_events: number of events used for validation
         :param int apply_events: number of events used for prediction
-        :param int cache_events: number of events to dump (cache) for future training
-                                 valid only for XGBoost
         """
-        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events,
-                         cache_events)
+        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events)
 
 class XGBoostSettings:
     name = "xgboost"
@@ -258,6 +247,8 @@ class XGBoostSettings:
         self.common_settings = common_settings
         self.logger.info("XGBoostSettings::Init")
 
+        self.params = data_param["params"]
+
         self.per_event_hists = False
         self.downsample = data_param["downsample"]
         self.downsample_npoints = data_param["downsample_npoints"]
@@ -265,7 +256,11 @@ class XGBoostSettings:
         self.train_plot_npoints = data_param["train_plot_npoints"]
         self.dump_train = data_param["dump_train"]
 
-        self.params = data_param["params"]
+        self.cache_events = data_param["cache_events"]
+        self.cache_file_size = data_param["cache_file_size"]
+        self.dirinput_cache = data_param["dirinput_cache"]
+        if not os.path.isdir(self.dirinput_cache):
+            os.makedirs(self.dirinput_cache)
 
         self.cache_suffix = "cache_phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
         self.cache_suffix = "%s_dpoints%d" % \
@@ -314,8 +309,7 @@ class XGBoostSettings:
             raise AttributeError("'XGBoostSettings' object has no attribute '%s'" % name) \
                 from attr_err
 
-    def set_ranges(self, ranges, total_events, train_events, val_events, apply_events,
-                   cache_events):
+    def set_ranges(self, ranges, total_events, train_events, val_events, apply_events):
         """
         A wrapper around internal set_ranges_().
 
@@ -324,7 +318,5 @@ class XGBoostSettings:
         :param int train_events: number of events used for training
         :param int val_events: number of events used for validation
         :param int apply_events: number of events used for prediction
-        :param int cache_events: number of events to dump (cache) for future training
         """
-        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events,
-                         cache_events)
+        self.set_ranges_(ranges, self.suffix, total_events, train_events, val_events, apply_events)

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -254,13 +254,13 @@ class XGBoostSettings:
         self.downsample_npoints = data_param["downsample_npoints"]
         self.plot_train = data_param["plot_train"]
         self.train_plot_npoints = data_param["train_plot_npoints"]
-        self.dump_train = data_param["dump_train"]
 
+        self.cache_train = data_param["cache_train"]
         self.cache_events = data_param["cache_events"]
         self.cache_file_size = data_param["cache_file_size"]
-        self.dirinput_cache = data_param["dirinput_cache"]
-        if not os.path.isdir(self.dirinput_cache):
-            os.makedirs(self.dirinput_cache)
+        self.dircache = data_param["dircache"]
+        if not os.path.isdir(self.dircache):
+            os.makedirs(self.dircache)
 
         self.cache_suffix = "cache_phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
         self.cache_suffix = "%s_dpoints%d" % \

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -263,8 +263,9 @@ class XGBoostSettings:
             os.makedirs(self.dircache)
 
         self.cache_suffix = "cache_phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
-        self.cache_suffix = "%s_dpoints%d" % \
-            (self.cache_suffix, self.downsample_npoints)
+        if self.downsample:
+            self.cache_suffix = "%s_dpoints%d" % \
+                (self.cache_suffix, self.downsample_npoints)
         self.cache_suffix = "%s_ftrain%d" % \
             (self.cache_suffix, self.num_fourier_coeffs_train)
 
@@ -285,9 +286,10 @@ class XGBoostSettings:
                 (self.suffix, self.opt_predout[0], self.opt_predout[1], self.opt_predout[2])
         self.suffix = "%s_input_z%.1f-%.1f" % \
                 (self.suffix, self.z_range[0], self.z_range[1])
-        self.suffix = "%s_dpoints%d" % \
-            (self.suffix, self.downsample_npoints)
-        self.suffix = "%s_n_coeffs_train%d" % \
+        if self.downsample:
+            self.suffix = "%s_dpoints%d" % \
+                (self.suffix, self.downsample_npoints)
+        self.suffix = "%s_ftrain%d" % \
             (self.suffix, self.num_fourier_coeffs_train)
 
         if not os.path.isdir("%s/%s" % (self.dirtree, self.suffix)):

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -267,7 +267,7 @@ class XGBoostSettings:
 
         self.params = data_param["params"]
 
-        self.cache_suffix = "phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
+        self.cache_suffix = "cache_phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
         self.cache_suffix = "%s_dpoints%d" % \
             (self.cache_suffix, self.downsample_npoints)
         self.cache_suffix = "%s_ftrain%d" % \

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -87,7 +87,8 @@ class CommonSettings:
         self.dirinput_nd_val = "%s/SC-%d-%d-%d" % (data_param["dirinput_nobias"],
                                self.grid_z, self.grid_r, self.grid_phi)
 
-        for dirname in (self.dirmodel, self.dirapply, self.dirplots, self.dirtree, self.dirhist):
+        for dirname in (self.dirmodel, self.dirapply, self.dirplots, self.dirtree, self.dirhist,
+                        self.dirinput_cache):
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
 
@@ -267,9 +268,9 @@ class XGBoostSettings:
         self.params = data_param["params"]
 
         self.cache_suffix = "phi%d_r%d_z%d" % (self.grid_phi, self.grid_r, self.grid_z)
-        self.cache_suffix = "%s_down_npoints%d" % \
+        self.cache_suffix = "%s_dpoints%d" % \
             (self.cache_suffix, self.downsample_npoints)
-        self.cache_suffix = "%s_fourier_train%d" % \
+        self.cache_suffix = "%s_ftrain%d" % \
             (self.cache_suffix, self.num_fourier_coeffs_train)
 
         self.suffix = "phi%d_r%d_z%d_nest%d_depth%d_lr%.3f_tm-%s" % \
@@ -289,7 +290,7 @@ class XGBoostSettings:
                 (self.suffix, self.opt_predout[0], self.opt_predout[1], self.opt_predout[2])
         self.suffix = "%s_input_z%.1f-%.1f" % \
                 (self.suffix, self.z_range[0], self.z_range[1])
-        self.suffix = "%s_down_npoints%d" % \
+        self.suffix = "%s_dpoints%d" % \
             (self.suffix, self.downsample_npoints)
         self.suffix = "%s_n_coeffs_train%d" % \
             (self.suffix, self.num_fourier_coeffs_train)

--- a/tpcwithdnn/config_model_parameters.yml
+++ b/tpcwithdnn/config_model_parameters.yml
@@ -4,6 +4,7 @@ common:
   dirplots: plots
   dirtree: trees
   dirhist: histograms
+  dirinput_cache: cache
   #dirinput_bias: /data/tpcml/data_20200518/bias
   #dirinput_nobias: /data/tpcml/data_20200518/nobias
   dirinput_bias: /mnt/temp/dsekihat/data/tpcml/data_20210414/noDistortions
@@ -41,6 +42,8 @@ xgboost:
   downsample_npoints: 100
   plot_train: false
   train_plot_npoints: 10
+  dump_train: true
+  cache_events: [200]
   params:
     n_estimators: 100 # 850, 100 is better than 500
     max_depth: 3

--- a/tpcwithdnn/config_model_parameters.yml
+++ b/tpcwithdnn/config_model_parameters.yml
@@ -4,7 +4,6 @@ common:
   dirplots: plots
   dirtree: trees
   dirhist: histograms
-  dirinput_cache: cache
   #dirinput_bias: /data/tpcml/data_20200518/bias
   #dirinput_nobias: /data/tpcml/data_20200518/nobias
   dirinput_bias: /mnt/temp/dsekihat/data/tpcml/data_20210414/noDistortions
@@ -43,7 +42,9 @@ xgboost:
   plot_train: false
   train_plot_npoints: 10
   dump_train: true
-  cache_events: [200]
+  cache_events: 200
+  cache_file_size: 10 # number of events, adjust to your RAM
+  dirinput_cache: cache
   params:
     n_estimators: 100 # 850, 100 is better than 500
     max_depth: 3

--- a/tpcwithdnn/config_model_parameters.yml
+++ b/tpcwithdnn/config_model_parameters.yml
@@ -41,10 +41,10 @@ xgboost:
   downsample_npoints: 100
   plot_train: false
   train_plot_npoints: 10
-  dump_train: true
+  cache_train: true
   cache_events: 200
   cache_file_size: 10 # number of events, adjust to your RAM
-  dirinput_cache: cache
+  dircache: cache
   params:
     n_estimators: 100 # 850, 100 is better than 500
     max_depth: 3

--- a/tpcwithdnn/config_model_parameters.yml
+++ b/tpcwithdnn/config_model_parameters.yml
@@ -14,7 +14,6 @@ common:
   nd_val_events: 1000 # Number of events for validation (random events for nd_validation)
   nd_val_partition: random # Whether the validator uses only the events from given partition
                            # 'random' is for choosing events randomly
-  nd_validate_model: true
   pdf_map_var: flucSC
   pdf_map_mean_id: 0
   grid_phi: 180

--- a/tpcwithdnn/data_validator.py
+++ b/tpcwithdnn/data_validator.py
@@ -85,34 +85,30 @@ class DataValidator:
             df_single_map[column_names[12 + ind_dist * 3]] = \
                 mat_der_ref_mean_dist[ind_dist, :]
 
-        if self.config.nd_validate_model:
-            input_single = np.empty((1, self.config.grid_phi, self.config.grid_r,
-                                     self.config.grid_z, self.config.dim_input))
-            index_fill_input = 0
-            if self.config.opt_train[0] == 1:
-                input_single[0, :, :, :, index_fill_input] = \
-                    vec_mean_sc.reshape(self.config.grid_phi, self.config.grid_r,
-                                        self.config.grid_z)
-                index_fill_input = index_fill_input + 1
-            if self.config.opt_train[1] == 1:
-                input_single[0, :, :, :, index_fill_input] = \
-                    vec_fluc_sc.reshape(self.config.grid_phi, self.config.grid_r,
-                                        self.config.grid_z)
+        input_single = np.empty((1, self.config.grid_phi, self.config.grid_r,
+                                 self.config.grid_z, self.config.dim_input))
+        index_fill_input = 0
+        if self.config.opt_train[0] == 1:
+            input_single[0, :, :, :, index_fill_input] = \
+                vec_mean_sc.reshape(self.config.grid_phi, self.config.grid_r,
+                                    self.config.grid_z)
+            index_fill_input = index_fill_input + 1
+        if self.config.opt_train[1] == 1:
+            input_single[0, :, :, :, index_fill_input] = \
+                vec_fluc_sc.reshape(self.config.grid_phi, self.config.grid_r,
+                                    self.config.grid_z)
 
-            mat_fluc_dist_predict_group = loaded_model.predict(input_single)
-            mat_fluc_dist_predict = np.empty((self.config.dim_output, vec_fluc_sc.size))
-            for ind_dist in range(self.config.dim_output):
-                mat_fluc_dist_predict[ind_dist, :] = \
-                    mat_fluc_dist_predict_group[0, :, :, :, ind_dist].flatten()
-                df_single_map[column_names[19 + ind_dist]] = \
-                    mat_fluc_dist_predict[ind_dist, :]
+        mat_fluc_dist_predict_group = loaded_model.predict(input_single)
+        mat_fluc_dist_predict = np.empty((self.config.dim_output, vec_fluc_sc.size))
+        for ind_dist in range(self.config.dim_output):
+            mat_fluc_dist_predict[ind_dist, :] = \
+                mat_fluc_dist_predict_group[0, :, :, :, ind_dist].flatten()
+            df_single_map[column_names[19 + ind_dist]] = \
+                mat_fluc_dist_predict[ind_dist, :]
 
-        tree_filename = "%s/%d/treeInput_mean%.2f_%s.root" \
-            % (dir_name, irnd, self.mean_factors[index_mean_id], self.config.suffix_ds)
-        if self.config.nd_validate_model:
-            tree_filename = "%s/%d/treeValidation_mean%.2f_nEv%d.root" \
-                            % (dir_name, irnd, self.mean_factors[index_mean_id],
-                               self.config.train_events)
+        tree_filename = "%s/%d/treeValidation_mean%.2f_nEv%d.root" \
+                        % (dir_name, irnd, self.mean_factors[index_mean_id],
+                           self.config.train_events)
 
         if not os.path.isdir("%s/%d" % (dir_name, irnd)):
             os.makedirs("%s/%d" % (dir_name, irnd))
@@ -133,16 +129,11 @@ class DataValidator:
             column_names = np.append(column_names, ["flucDist" + dist_name,
                                                     "meanDist" + dist_name,
                                                     "derRefMeanDist" + dist_name])
-        if self.config.nd_validate_model:
-            loaded_model = self.model.load_model()
-            for dist_name in dist_names:
-                column_names = np.append(column_names, ["flucDist" + dist_name + "Pred"])
-        else:
-            loaded_model = None
+        loaded_model = self.model.load_model()
+        for dist_name in dist_names:
+            column_names = np.append(column_names, ["flucDist" + dist_name + "Pred"])
 
-        dir_name = "%s/parts" % (self.config.dirtree)
-        if self.config.nd_validate_model:
-            dir_name = "%s/%s/parts" % (self.config.dirtree, self.config.suffix)
+        dir_name = "%s/%s/parts" % (self.config.dirtree, self.config.suffix)
         if os.path.isdir(dir_name):
             shutil.rmtree(dir_name)
 

--- a/tpcwithdnn/default.yml
+++ b/tpcwithdnn/default.yml
@@ -4,7 +4,7 @@ doplot: false
 dogrid: false
 dobayes: false
 doprofile: false
-dodumptraindata: false
+docache: true
 docreatendvaldata: false
 docreatepdfmaps: false
 docreatepdfmapforvariable: false

--- a/tpcwithdnn/default.yml
+++ b/tpcwithdnn/default.yml
@@ -4,7 +4,7 @@ doplot: false
 dogrid: false
 dobayes: false
 doprofile: false
-docache: true
+docache: false
 docreatendvaldata: false
 docreatepdfmaps: false
 docreatepdfmapforvariable: false

--- a/tpcwithdnn/default.yml
+++ b/tpcwithdnn/default.yml
@@ -4,6 +4,7 @@ doplot: false
 dogrid: false
 dobayes: false
 doprofile: false
+dodumptraindata: false
 docreatendvaldata: false
 docreatepdfmaps: false
 docreatepdfmapforvariable: false

--- a/tpcwithdnn/dnn_optimiser.py
+++ b/tpcwithdnn/dnn_optimiser.py
@@ -77,7 +77,7 @@ class DnnOptimiser(Optimiser):
                         use_multiprocessing=False,
                         epochs=self.config.epochs, callbacks=[tensorboard_callback])
 
-        self.plot_train_(his)
+        self.__plot_train(his)
         self.save_model(model)
 
     def apply(self):
@@ -180,7 +180,7 @@ class DnnOptimiser(Optimiser):
                                    self.config.train_events))
         return loaded_model
 
-    def plot_train_(self, his):
+    def __plot_train(self, his):
         """
         Plot the learning curve for 3D calibration.
         Function used internally.

--- a/tpcwithdnn/hadd.py
+++ b/tpcwithdnn/hadd.py
@@ -19,7 +19,7 @@ def merge_root_file(target, source_list):
     logger = get_logger()
     raw_path = target.GetPath()
     path = raw_path[raw_path.find(":")+1:]
-    logger.info("Target path: %s processed: %s" % (raw_path, path))
+    logger.info("Target path: %s processed: %s", raw_path, path)
 
     first_source = source_list.First()
     first_source.cd(path)
@@ -44,7 +44,7 @@ def merge_root_file(target, source_list):
 
         if obj.IsA().InheritsFrom(TH1.Class()):
             # descendant of TH1 -> merge it
-            logger.info("Merging histogram %s" % obj.GetName())
+            logger.info("Merging histogram %s", obj.GetName())
             h1 = TH1(obj)
 
             # loop over all source files and add the content of the
@@ -61,7 +61,7 @@ def merge_root_file(target, source_list):
                 next_source = source_list.After(next_source)
 
         elif obj.IsA().InheritsFrom(TTree.Class()):
-            logger.info("Merging tree %s" % obj.GetName())
+            logger.info("Merging tree %s", obj.GetName())
             # loop over all source files and create a chain of Trees "global_chain"
             obj_name = obj.GetName()
             global_chain = TChain(obj_name)
@@ -72,7 +72,7 @@ def merge_root_file(target, source_list):
                 next_source = source_list.After(next_source)
 
         elif obj.IsA().InheritsFrom(TDirectory.Class()):
-            logger.info("Found subdirectory %s" % obj.GetName())
+            logger.info("Found subdirectory %s", obj.GetName())
             # create a new subdir of same name and title in the target file
             target.cd()
             new_dir = target.mkdir(obj.GetName(), obj.GetTitle())
@@ -82,7 +82,7 @@ def merge_root_file(target, source_list):
             merge_root_file(new_dir, source_list)
 
         else:
-            logger.info("Unknown object type, name: %s, title: %s" % (obj.GetName(), obj.GetTitle()))
+            logger.info("Unknown object type, name: %s, title: %s", obj.GetName(), obj.GetTitle())
 
         # now write the merged histogram (which is "in" obj) to the target file
         # note that this will just store obj in the current directory level,

--- a/tpcwithdnn/hadd.py
+++ b/tpcwithdnn/hadd.py
@@ -1,0 +1,118 @@
+"""
+A pyROOT version of $ROOTSYS/tutorials/io/hadd.C for merging ROOT files.
+"""
+
+from ROOT import TList, TH1, TIter # pylint: disable=import-error, no-name-in-module
+from ROOT import TFile, TDirectory, TTree, TChain # pylint: disable=import-error, no-name-in-module
+from ROOT import gDirectory # pylint: disable=import-error, no-name-in-module
+
+from tpcwithdnn.logger import get_logger
+
+def merge_root_file(target, source_list):
+    """
+    Merge next file from the source list with the target file.
+    Function called recursively for each element of the list.
+
+    :param TFile target: the result ROOT file
+    :param TList source_list: list of input files to merge
+    """
+    logger = get_logger()
+    raw_path = target.GetPath()
+    path = raw_path[raw_path.find(":")+1:]
+    logger.info("Target path: %s processed: %s" % (raw_path, path))
+
+    first_source = source_list.First()
+    first_source.cd(path)
+    current_source_dir = gDirectory
+    # gain time, do not add the objects in the list in memory
+    status = TH1.AddDirectoryStatus()
+    TH1.AddDirectory(False)
+
+    # loop over all keys in this directory
+    #global_chain = TChain()
+    next_key = TIter(current_source_dir.GetListOfKeys())
+    #key = TKey()
+    #TKey old_key = None
+    key = next_key()
+    while key:
+        # keep only the highest cycle number for each key
+        #if old_key and not old_key.GetName() == key.GetName():
+        #    continue
+        # read object from first source file
+        first_source.cd(path)
+        obj = key.ReadObj()
+
+        if obj.IsA().InheritsFrom(TH1.Class()):
+            # descendant of TH1 -> merge it
+            logger.info("Merging histogram %s" % obj.GetName())
+            h1 = TH1(obj)
+
+            # loop over all source files and add the content of the
+            # correspondant histogram to the one pointed to by "h1"
+            next_source = source_list.After(first_source)
+            while next_source:
+                # make sure we are at the correct directory level by cd'ing to path
+                next_source.cd(path)
+                key2 = gDirectory.GetListOfKeys().FindObject(h1.GetName())
+                if key2:
+                    h2 = TH1(key2.ReadObj())
+                    h1.Add(h2)
+                    #del h2
+                next_source = source_list.After(next_source)
+
+        elif obj.IsA().InheritsFrom(TTree.Class()):
+            logger.info("Merging tree %s" % obj.GetName())
+            # loop over all source files and create a chain of Trees "global_chain"
+            obj_name = obj.GetName()
+            global_chain = TChain(obj_name)
+            global_chain.Add(first_source.GetName())
+            next_source = source_list.After(first_source)
+            while next_source:
+                global_chain.Add(next_source.GetName())
+                next_source = source_list.After(next_source)
+
+        elif obj.IsA().InheritsFrom(TDirectory.Class()):
+            logger.info("Found subdirectory %s" % obj.GetName())
+            # create a new subdir of same name and title in the target file
+            target.cd()
+            new_dir = target.mkdir(obj.GetName(), obj.GetTitle())
+            # newdir is now the starting point of another round of merging
+            # newdir still knows its depth within the target file via
+            # GetPath(), so we can still figure out where we are in the recursion
+            merge_root_file(new_dir, source_list)
+
+        else:
+            logger.info("Unknown object type, name: %s, title: %s" % (obj.GetName(), obj.GetTitle()))
+
+        # now write the merged histogram (which is "in" obj) to the target file
+        # note that this will just store obj in the current directory level,
+        # which is not persistent until the complete directory itself is stored
+        # by "target.Write()" below
+        if obj is not None:
+            target.cd()
+            # if the object is a tree, it is stored in global_chain...
+            if obj.IsA().InheritsFrom(TTree.Class()):
+                global_chain.Merge(target.GetFile(), 0, "keep")
+            else:
+                obj.Write(key.GetName())
+
+        # move to the next element
+        key = next_key()
+
+    # save modifications to target file
+    target.SaveSelf(True)
+    TH1.AddDirectory(status)
+    target.Write()
+
+def hadd(input_file_names, result_file_name):
+    """
+    The top function for merging files.
+
+    :param str result_file_name: path to the output file
+    :param list[str] source_list: list of paths to the input files
+    """
+    target = TFile.Open(result_file_name, "RECREATE")
+    file_list = TList()
+    for file_name in input_file_names:
+        file_list.Add(TFile.Open(file_name))
+    merge_root_file(target, file_list)

--- a/tpcwithdnn/hadd.py
+++ b/tpcwithdnn/hadd.py
@@ -19,7 +19,6 @@ def merge_root_file(target, source_list):
     logger = get_logger()
     raw_path = target.GetPath()
     path = raw_path[raw_path.find(":")+1:]
-    logger.info("Target path: %s processed: %s", raw_path, path)
 
     first_source = source_list.First()
     first_source.cd(path)

--- a/tpcwithdnn/idc_data_validator.py
+++ b/tpcwithdnn/idc_data_validator.py
@@ -204,8 +204,8 @@ class IDCDataValidator:
         """
         self.config.logger.info("DataValidator::create_nd_histogram, var = %s, mean_id = %d",
                                 var, mean_id)
-        self.check_mean_id_(mean_id)
-        mean_factor = self.get_mean_factor_(mean_id)
+        self.__check_mean_id(mean_id)
+        mean_factor = self.__get_mean_factor(mean_id)
 
         column_names = ['phi', 'r', 'z', 'deltaSC']
         diff_index = var.find("Diff")
@@ -272,8 +272,8 @@ class IDCDataValidator:
         """
         self.config.logger.info("DataValidator::create_pdf_map, var = %s, mean_id = %d",
                                 var, mean_id)
-        self.check_mean_id_(mean_id)
-        mean_factor = self.get_mean_factor_(mean_id)
+        self.__check_mean_id(mean_id)
+        mean_factor = self.__get_mean_factor(mean_id)
 
         input_file_name = "%s/%s/ndHistogram_%s_mean%.2f_nEv%d.gzip" \
             % (self.config.dirhist, self.config.suffix, var, mean_factor,
@@ -358,10 +358,10 @@ class IDCDataValidator:
 
         :param int mean_id: index of mean map.
         """
-        self.check_mean_id_(mean_id)
+        self.__check_mean_id(mean_id)
         self.merge_pdf_maps([mean_id])
 
-    def check_mean_id_(self, mean_id):
+    def __check_mean_id(self, mean_id):
         """
         A shortcut to check mean map id, as many functions are designed only for specific ids.
 
@@ -372,7 +372,7 @@ class IDCDataValidator:
                                      self.mean_ids)
             self.config.logger.fatal("Exiting...")
 
-    def get_mean_factor_(self, mean_id):
+    def __get_mean_factor(self, mean_id):
         """
         Convert mean map id to a mean factor
 

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -130,11 +130,6 @@ def run_model_and_val(model, dataval, default, config_parameters):
         model.plot()
     if default["dogrid"] is True:
         model.search_grid()
-    if default["docache"] is True and model.name == "xgboost":
-        start = timer()
-        model.cache_train_data()
-        end = timer()
-        log_time(start, end, "cache")
     if default["docreatendvaldata"] is True:
         dataval.create_data()
     if default["docreatepdfmaps"] is True:
@@ -196,7 +191,8 @@ def main():
                         help="Set the number of events to cache")
     parser.add_argument("--cache-train", action="store_true", default=argparse.SUPPRESS,
                         help="Use cached data for training")
-    parser.add_argument("--cache-file-size", dest="cache_file_size", type=int, default=argparse.SUPPRESS,
+    parser.add_argument("--cache-file-size", dest="cache_file_size", type=int,
+                        default=argparse.SUPPRESS,
                         help="Set the number of events per single temporary cache file")
     args = parser.parse_args()
 
@@ -249,6 +245,12 @@ def main():
         max_available_events = (ranges_rnd[1] + 1 - ranges_rnd[0]) * \
             (ranges_mean[1] + 1 - ranges_mean[0])
 
+    for model in models:
+        if default["docache"] is True and model.name == "xgboost":
+            start = timer()
+            model.cache_train_data()
+            end = timer()
+            log_time(start, end, "cache")
     for model, model_events_counts in zip(models, events_counts):
         all_events_counts = []
         for (train_events, val_events, apply_events) in model_events_counts:

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -253,7 +253,8 @@ def main():
             ranges = {"train": [0, train_events],
                       "validation": [train_events, train_events + val_events],
                       "apply": [train_events + val_events, total_events]}
-            model.config.set_ranges(ranges, total_events, train_events, val_events, apply_events, cache_events)
+            model.config.set_ranges(ranges, total_events, train_events, val_events, apply_events,
+                                    cache_events)
 
             run_model_and_val(model, dataval, default, config_parameters["common"])
 

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -212,9 +212,6 @@ def main():
         default["dotrain"] = True
     if "docreateinputdata" in args or "docreatendvaldata" in args:
         default["docreatendvaldata"] = True
-        config_parameters["common"]["nd_validate_model"] = False
-    if "docreatendvaldata" in args:
-        config_parameters["common"]["nd_validate_model"] = True
     if "rndaugment" in args:
         config_parameters["common"]["rnd_augment"] = True
     if "train_events_oned" in args:

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -191,6 +191,13 @@ def main():
     parser.add_argument("--nfourierapply", dest="num_fourier_coeffs_apply", type=int,
                         default=argparse.SUPPRESS, help="Set number of Fourier coefficients" \
                         " to take from the 1D IDC apply input")
+    # parameters for caching
+    parser.add_argument("--cache-events", dest="cache_events", type=int, default=argparse.SUPPRESS,
+                        help="Set the number of events to cache")
+    parser.add_argument("--cache-train", action="store_true", default=argparse.SUPPRESS,
+                        help="Use cached data for training")
+    parser.add_argument("--cache-file-size", dest="cache_file_size", type=int, default=argparse.SUPPRESS,
+                        help="Set the number of events per single temporary cache file")
     args = parser.parse_args()
 
     logger.info("Using configuration: %s steer file: %s", args.config_file, args.steer_file)
@@ -225,6 +232,12 @@ def main():
         config_parameters["common"]["num_fourier_coeffs_train"] = args.num_fourier_coeffs_train
     if "num_fourier_coeffs_apply" in args:
         config_parameters["common"]["num_fourier_coeffs_apply"] = args.num_fourier_coeffs_apply
+    if "cache_events" in args:
+        config_parameters["xgboost"]["cache_events"] = args.cache_events
+    if "cache_train" in args:
+        config_parameters["xgboost"]["cache_train"] = True
+    if "cache_file_size" in args:
+        config_parameters["xgboost"]["cache_file_size"] = args.cache_file_size
 
     models, corr, dataval = init_models(config_parameters)
     events_counts = (get_events_counts(config_parameters[model.name]["train_events"],

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -96,7 +96,7 @@ def get_events_counts(train_events, val_events, apply_events):
     :rtype: zip
     """
     if len(train_events) != len(val_events) or \
-            len(train_events) != len(apply_events):
+       len(train_events) != len(apply_events):
         raise ValueError("Different number of ranges specified for train/validation/apply")
     return zip(train_events, val_events, apply_events)
 
@@ -131,7 +131,10 @@ def run_model_and_val(model, dataval, default, config_parameters):
     if default["dogrid"] is True:
         model.search_grid()
     if default["docache"] is True and model.name == "xgboost":
+        start = timer()
         model.cache_train_data()
+        end = timer()
+        log_time(start, end, "cache")
     if default["docreatendvaldata"] is True:
         dataval.create_data()
     if default["docreatepdfmaps"] is True:

--- a/tpcwithdnn/xgboost_optimiser.py
+++ b/tpcwithdnn/xgboost_optimiser.py
@@ -45,24 +45,24 @@ class XGBoostOptimiser(Optimiser):
         self.config.logger.info("XGBoostOptimiser::train")
         model = XGBRFRegressor(verbosity=1, **(self.config.params))
         start = timer()
-        inputs, exp_outputs = self.get_data_("train")
+        inputs, exp_outputs = self.__get_data("train")
         end = timer()
         log_time(start, end, "for loading training data")
         log_memory_usage(((inputs, "Input train data"), (exp_outputs, "Output train data")))
         log_total_memory_usage("Memory usage after loading data")
         if self.config.plot_train:
-            inputs_val, outputs_val = self.get_data_("validation")
+            inputs_val, outputs_val = self.__get_data("validation")
             log_memory_usage(((inputs_val, "Input validation data"),
                               (outputs_val, "Output validation data")))
             log_total_memory_usage("Memory usage after loading validation data")
-            self.plot_train_(model, inputs, exp_outputs, inputs_val, outputs_val)
+            self.__plot_train(model, inputs, exp_outputs, inputs_val, outputs_val)
         start = timer()
         model.fit(inputs, exp_outputs)
         end = timer()
         log_time(start, end, "actual train")
         model.get_booster().feature_names = get_input_names_oned_idc(
             self.config.num_fourier_coeffs_train)
-        self.plot_feature_importance_(model)
+        self.__plot_feature_importance(model)
         self.save_model(model)
 
     def apply(self):
@@ -71,14 +71,14 @@ class XGBoostOptimiser(Optimiser):
         """
         self.config.logger.info("XGBoostOptimiser::apply, input size: %d", self.config.dim_input)
         loaded_model = self.load_model()
-        inputs, exp_outputs = self.get_data_("apply")
+        inputs, exp_outputs = self.__get_data("apply")
         log_memory_usage(((inputs, "Input apply data"), (exp_outputs, "Output apply data")))
         log_total_memory_usage("Memory usage after loading apply data")
         start = timer()
         pred_outputs = loaded_model.predict(inputs)
         end = timer()
         log_time(start, end, "actual predict")
-        self.plot_apply_(exp_outputs, pred_outputs)
+        self.__plot_apply(exp_outputs, pred_outputs)
         self.config.logger.info("Done apply")
 
     def search_grid(self):
@@ -124,7 +124,23 @@ class XGBoostOptimiser(Optimiser):
             model = pickle.load(file)
         return model
 
-    def get_data_(self, partition):
+    def cache_train_data(self):
+        """
+        Cache train data if it is not cached.
+        """
+        self.config.logger.info("Searching for cached data")
+        filename = "%s_cacheEv%d" % (self.config.cache_suffix, self.config.cache_events)
+        full_path = "%s/%s" % (self.config.dircache, filename)
+        cache_file = "%s.root" % full_path
+        try:
+            with open(cache_file, encoding="utf-8") as _ :
+                self.config.logger.info("Found cache: %s", cache_file)
+        except FileNotFoundError:
+            self.config.set_cache_ranges()
+            self.__save_cache(full_path, "train", self.config.downsample,
+                             self.config.num_fourier_coeffs_train)
+
+    def __get_data(self, partition):
         """
         Load the full input data for a XGBoost optimization.
         Function used internally.
@@ -140,14 +156,13 @@ class XGBoostOptimiser(Optimiser):
             # Take all Fourier coefficients for training
             num_fourier_coeffs_apply = self.config.num_fourier_coeffs_train
             if self.config.cache_train and self.config.train_events <= self.config.cache_events:
-                return self.get_cache_(partition, downsample, num_fourier_coeffs_apply,
-                                       resave=False)
-            elif self.config.cache_train:
-                self.logger.warning("Cache insufficient, the train data will be read \
-                                    from the original files")
-        return self.get_partition_(partition, downsample, num_fourier_coeffs_apply, slice(None))
+                return self.__get_cache()
+            if self.config.cache_train:
+                self.config.logger.warning("Cache insufficient, the train data will be read \
+                                            from the original files")
+        return self.__get_partition(partition, downsample, num_fourier_coeffs_apply, slice(None))
 
-    def get_partition_(self, partition, downsample, num_fourier_coeffs_apply, part_range):
+    def __get_partition(self, partition, downsample, num_fourier_coeffs_apply, part_range):
         """
         Load the input data from given partition. Function used internally.
 
@@ -162,6 +177,7 @@ class XGBoostOptimiser(Optimiser):
         dirinput = getattr(self.config, "dirinput_" + partition)
         inputs = []
         exp_outputs = []
+        indices = []
         for indexev in self.config.partition[partition][part_range]:
             inputs_single, exp_outputs_single = load_data_oned_idc(self.config, dirinput,
                                                            indexev, downsample,
@@ -169,34 +185,61 @@ class XGBoostOptimiser(Optimiser):
                                                            num_fourier_coeffs_apply)
             inputs.append(inputs_single)
             exp_outputs.append(exp_outputs_single)
+
+            vec_index_random = np.empty(inputs_single.shape[0])
+            vec_index_random[:] = indexev[0]
+            vec_index_mean = np.empty(inputs_single.shape[0])
+            vec_index_mean[:] = indexev[1]
+            vec_index = np.empty(inputs_single.shape[0])
+            vec_index[:] = indexev[0] + 1000 * indexev[1]
+            indices_single = np.array((vec_index.astype('int32'), vec_index_mean.astype('int32'),
+                                       vec_index_random.astype('int32')))
+            indices_stacked = np.vstack(indices_single.reshape(-1, 3))
+            indices.append(indices_stacked)
         inputs = np.concatenate(inputs)
         exp_outputs = np.concatenate(exp_outputs)
+        indices = np.concatenate(indices)
 
-        return inputs, exp_outputs
+        return inputs, exp_outputs, indices
 
-    def cache_train_data(self):
+    def __save_cache(self, full_path, partition, downsample, num_fourier_coeffs_apply):
         """
-        Cache train data if it is not cached.
-        """
-        self.get_cache_("train", self.config.downsample, self.config.num_fourier_coeffs_train,
-                        resave=True)
+        Save the cache for given partition. Function used internally.
 
-    def read_cache_from_file(self, filepath):
+        :param str full_path: full path to the target cache file without the '.root' extension
+        :param str partition: name of partition, one from "train", "validation", "apply"
+        :param bool downsample: whether to downsample the data
+        :param int num_fourier_coeffs_apply: number of Fourier coefficients for applying
         """
-        Read the cached data from the file specified. Function used internally.
+        cache_file = "%s.root" % full_path
+        self.config.logger.info("Saving new cache to %s", cache_file)
+        fourier_names = list(chain.from_iterable(("c%d_real" % i, "c%d_imag" % i)
+                             for i in range(self.config.num_fourier_coeffs_train)))
+        dist_names = np.array(self.config.nameopt_predout)
+        dist_names = dist_names[np.array(self.config.opt_predout) > 0]
+        fluc_corr_names = ["flucCorr" + dist_name for dist_name in dist_names]
+        batch_file_names = []
+        batch_size = self.config.cache_file_size
+        for i, part_range in enumerate(self.__get_batch_range(partition, batch_size)):
+            inputs, exp_outputs, indices = self.__get_partition(partition, downsample,
+                                                               num_fourier_coeffs_apply,
+                                                               part_range)
 
-        :param str filepath: full path to the cache file
-        :return: tuple of inputs and expected outputs
-        :rtype: tuple(np.ndarray, np.ndarray)
-        """
-        self.config.logger.info("Reading cache from %s", filepath)
-        input_data = tree_to_pandas(filepath, "cache")
-        inputs = input_data.filter(regex="^(?!exp).*").to_numpy()
-        exp_outputs = input_data.filter(like="exp").to_numpy()
-        self.config.logger.info("Data read from cache: %s", filepath)
-        return inputs, exp_outputs
+            input_data = np.hstack((indices, inputs, exp_outputs.reshape(-1, 1)))
+            cache_data = pd.DataFrame(input_data,
+                                      columns=["eventId", "meanId", "randomId",
+                                               "r", "phi", "z", "derRefMeanCorr"] +\
+                                              fourier_names + fluc_corr_names)
+            batch_file = "%s_%d.root" % (full_path, i)
+            batch_file_names.append(batch_file)
+            pandas_to_tree(cache_data, batch_file, "cache")
+            self.config.logger.info("Cache: %s saved", batch_file)
+        hadd(batch_file_names, cache_file)
+        for batch_file in batch_file_names:
+            os.remove(batch_file)
+        self.config.logger.info("Merged cache: %s saved", cache_file)
 
-    def get_batch_range_(self, partition, batch_size):
+    def __get_batch_range(self, partition, batch_size):
         """
         A generator to calculate the next batch of data from the partition.
 
@@ -212,56 +255,50 @@ class XGBoostOptimiser(Optimiser):
         if last_full_end < data_size:
             yield slice(last_full_end, data_size)
 
-    def get_cache_(self, partition, downsample, num_fourier_coeffs_apply, resave):
+    def __read_cache_from_file(self, filepath, events_count):
         """
-        Get the cached data from given partition. Function used internally.
+        Read the cached data from the file specified. Function used internally.
 
-        :param str partition: name of partition, one from "train", "validation", "apply"
-        :param bool downsample: whether to downsample the data
-        :param int num_fourier_coeffs_apply: number of Fourier coefficients for applying
-        :param bool resave: whether to save the cache if a matching cache file does not exist
-        :return: tuple of inputs and expected outputs
-        :rtype: tuple(np.ndarray, np.ndarray)
+        :param str filepath: full path to the cache file
+        :param int events_count: number of events to read
+        :return: tuple of inputs, expected outputs and event indices
+        :rtype: tuple(np.ndarray, np.ndarray, np.ndarray)
+        """
+        self.config.logger.info("Reading cache from %s", filepath)
+        points_per_event = self.config.downsample_npoints
+        if not self.config.downsample:
+            points_per_event = self.config.phi * self.config.r * self.config.z
+        data_size = points_per_event * events_count
+        input_data = tree_to_pandas(filepath, "cache")
+        input_data = input_data.iloc[:data_size, :]
+        indices = input_data[["eventId", "meanId", "randomId"]].to_numpy()
+        inputs = input_data.filter(regex="^(?!flucCorr).*")
+        inputs = inputs.drop(["eventId", "meanId", "randomId"], axis=1)
+        inputs = inputs.to_numpy()
+        exp_outputs = input_data.filter(like="flucCorr").to_numpy()
+        self.config.logger.info("Data read from cache: %s", filepath)
+        return inputs, exp_outputs, indices
+
+    def __get_cache(self):
+        """
+        Get the cached data. Function used internally.
+
+        :return: tuple of inputs, expected outputs and event indices
+        :rtype: tuple(np.ndarray, np.ndarray, np.ndarray)
         """
         self.config.logger.info("Searching for cached data")
-        filename = "%s_%sEv%d" % (self.config.cache_suffix, partition, self.config.cache_events)
+
+        filename = "%s_cacheEv%d" % (self.config.cache_suffix, self.config.cache_events)
         full_path = "%s/%s" % (self.config.dircache, filename)
         cache_file = "%s.root" % full_path
         try:
-            inputs, exp_outputs = self.read_cache_from_file(cache_file)
-            self.config.logger.info("Found cache: %s", cache_file)
-            return inputs, exp_outputs
+            inputs, exp_outputs, _ = self.__read_cache_from_file(cache_file,
+                                                                self.config.train_events)
         except FileNotFoundError:
-            if not resave:
-                self.config.logger.fatal("Cache: %s does not exist, no data for training!",
-                                            cache_file)
-            self.config.logger.info("Cache: %s does not exist, saving new cache", cache_file)
-            fourier_names = list(chain.from_iterable(("Fourier real %d" % i, "Fourier imag %d" % i)
-                                 for i in range(self.config.num_fourier_coeffs_train)))
-            dist_names = np.array(self.config.nameopt_predout)[np.array(self.config.opt_predout) > 0]
-            fluc_corr_names = ["flucCorr" + dist_name for dist_name in dist_names]
-            batch_file_names = []
-            batch_size = self.config.cache_file_size
-            for i, part_range in enumerate(self.get_batch_range_(partition, batch_size)):
-                inputs, exp_outputs = self.get_partition_(partition, downsample,
-                                                          num_fourier_coeffs_apply, part_range)
+            self.config.logger.fatal("Cache: %s does not exist, no data for training!", cache_file)
+        return inputs, exp_outputs
 
-                input_data = np.hstack((inputs, exp_outputs.reshape(-1, 1)))
-                cache_data = pd.DataFrame(input_data,
-                                          columns=["eventId", "meanId", "randomId",
-                                                   "r", "phi", "z", "derRefMeanCorr"] +\
-                                                  fourier_names + fluc_corr_names)
-                batch_file = "%s_%d.root" % (full_path, i)
-                batch_file_names.append(batch_file)
-                pandas_to_tree(cache_data, batch_file, "cache")
-                self.config.logger.info("Cache: %s saved", batch_file)
-            hadd(batch_file_names, cache_file)
-            for batch_file in batch_file_names:
-                os.remove(batch_file)
-            self.config.logger.info("Merged cache: %s saved", cache_file)
-            return self.read_cache_from_file(cache_file)
-
-    def plot_feature_importance_(self, model):
+    def __plot_feature_importance(self, model):
         """
         Create plots and text file of feature importances (total gain, weight, gain).
 
@@ -315,7 +352,7 @@ class XGBoostOptimiser(Optimiser):
                          self.config.train_events))
 
 
-    def plot_apply_(self, exp_outputs, pred_outputs):
+    def __plot_apply(self, exp_outputs, pred_outputs):
         """
         Create result histograms in the output ROOT file after applying the model.
         Function used internally.
@@ -325,7 +362,7 @@ class XGBoostOptimiser(Optimiser):
         """
         myfile = TFile.Open("%s/output_%s_fapply%d_nEv%d.root" % \
                             (self.config.dirapply, self.config.suffix,
-                             self.num_fourier_coeffs_apply, self.config.train_events),
+                             self.config.num_fourier_coeffs_apply, self.config.train_events),
                             "recreate")
         h_dist_all_events, h_deltas_all_events, h_deltas_vs_dist_all_events =\
                 plot_utils.create_apply_histos(self.config, self.config.suffix, infix="all_events_")
@@ -345,7 +382,7 @@ class XGBoostOptimiser(Optimiser):
 
         myfile.Close()
 
-    def plot_train_(self, model, x_train, y_train, x_val, y_val):
+    def __plot_train(self, model, x_train, y_train, x_val, y_val):
         """
         Plot the learning curve for 1D calibration.
         Function used internally.
@@ -369,8 +406,8 @@ class XGBoostOptimiser(Optimiser):
             train_errors.append(mean_squared_error(y_train_predict, y_train[:checkpoint]))
             val_errors.append(mean_squared_error(y_val_predict, y_val))
             if ind in (0, self.config.train_plot_npoints // 2, self.config.train_plot_npoints - 1):
-                self.plot_results_(y_train[:checkpoint], y_train_predict, "train-%d" % ind)
-                self.plot_results_(y_val, y_val_predict, "val-%d" % ind)
+                self.__plot_results(y_train[:checkpoint], y_train_predict, "train-%d" % ind)
+                self.__plot_results(y_val, y_val_predict, "val-%d" % ind)
         self.config.logger.info("Memory usage during plot train")
         log_total_memory_usage()
         plt.plot(checkpoints, np.sqrt(train_errors), ".", label="train")
@@ -384,7 +421,7 @@ class XGBoostOptimiser(Optimiser):
                                                        self.config.train_events))
         plt.clf()
 
-    def plot_results_(self, exp_outputs, pred_outputs, infix):
+    def __plot_results(self, exp_outputs, pred_outputs, infix):
         """
         Plot the diagram of predicted vs expected 1D calibration output after applying the model.
         Function used internally.
@@ -398,5 +435,6 @@ class XGBoostOptimiser(Optimiser):
         plt.xlabel("Expected output")
         plt.ylabel("Predicted output")
         plt.savefig("%s/num-exp-%s_%s_fapply%d_nEv%d.png" % (self.config.dirplots, infix,
-                    self.config.suffix, self.num_fourier_coeffs_apply, self.config.train_events))
+                    self.config.suffix, self.config.num_fourier_coeffs_apply,
+                    self.config.train_events))
         plt.clf()

--- a/tpcwithdnn/xgboost_optimiser.py
+++ b/tpcwithdnn/xgboost_optimiser.py
@@ -209,7 +209,7 @@ class XGBoostOptimiser(Optimiser):
         data_size = len(self.config.partition[partition])
         last_full_end = int(np.floor(data_size / batch_size)) * batch_size
         for i in range(0, last_full_end, batch_size):
-            yield slice(i, i + 1)
+            yield slice(i, i + batch_size)
         if last_full_end < data_size:
             yield slice(last_full_end, data_size)
 
@@ -240,6 +240,7 @@ class XGBoostOptimiser(Optimiser):
             for i, part_range in enumerate(self.get_batch_range_(partition, batch_size)):
                 inputs, exp_outputs = self.get_partition_(partition, downsample,
                                                           num_fourier_coeffs_apply, part_range)
+
                 input_data = np.hstack((inputs, exp_outputs.reshape(-1, 1)))
                 cache_data = pd.DataFrame(input_data,
                                           columns=["r", "phi", "z", "der mean corr"] +\

--- a/tpcwithdnn/xgboost_optimiser.py
+++ b/tpcwithdnn/xgboost_optimiser.py
@@ -138,8 +138,8 @@ class XGBoostOptimiser(Optimiser):
             downsample = self.config.downsample
             # Take all Fourier coefficients for training
             num_fourier_coeffs_apply = self.config.num_fourier_coeffs_train
-            if self.config.dump_train:
-                return self.get_cache_(partition, downsample, num_fourier_coeffs_apply)
+        if self.config.dump_train:
+            return self.get_cache_(partition, downsample, num_fourier_coeffs_apply)
         return self.get_partition_(partition, downsample, num_fourier_coeffs_apply)
 
     def get_partition_(self, partition, downsample, num_fourier_coeffs_apply):
@@ -185,7 +185,8 @@ class XGBoostOptimiser(Optimiser):
         :rtype: tuple(np.ndarray, np.ndarray)
         """
         self.config.logger.info("Searching for cached data")
-        filename = "%s_cacheEv%d.root" % (self.config.cache_suffix, self.config.cache_events)
+        events_count = getattr(self.config, "%s_events" % partition)
+        filename = "%s_%sEv%d.root" % (self.config.cache_suffix, partition, events_count)
         full_path = "%s/%s" % (self.config.dirinput_cache, filename)
         try:
             input_data = tree_to_pandas(full_path, "cache", ["*"])


### PR DESCRIPTION
Hello @ehellbar , here is ready data dump.

For now, caching is enabled for train/apply/validation.
It saves the number of events specified wrt these partitions.
We can re-discuss tomorrow the idea of separate 'cache_events" count, and what we want to save in cache.