### PR TITLE
Bump python to 3.8 for CI checks

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.6]
+        python-version: [3.8]
         test-tool: [pylint, pytest]
 
     steps:


### PR DESCRIPTION
Python 3.6 is no longer available