### PR TITLE
Adding number of applied Fourier coeffs to validation tree file

### DIFF
--- a/tpcwithdnn/idc_data_validator.py
+++ b/tpcwithdnn/idc_data_validator.py
@@ -138,8 +138,9 @@ class IDCDataValidator:
         dir_name = "%s/%s/parts/%d" % (self.config.dirtree, self.config.suffix, irnd)
         if not os.path.isdir(dir_name):
             os.makedirs(dir_name)
-        tree_filename = "%s/validation_mean%.2f_nEv%d.root" \
-            % (dir_name, self.mean_factors[self.mean_ids.index(mean_id)], self.config.train_events)
+        tree_filename = "%s/validation_mean%.2f_nEv%d_fapply%d.root" \
+            % (dir_name, self.mean_factors[self.mean_ids.index(mean_id)], self.config.train_events,
+               self.config.num_fourier_coeffs_apply)
         pandas_to_tree(df_single_map, tree_filename, 'validation')
 
 

--- a/tpcwithdnn/xgboost_optimiser.py
+++ b/tpcwithdnn/xgboost_optimiser.py
@@ -227,7 +227,7 @@ class XGBoostOptimiser(Optimiser):
             input_data = np.hstack((indices, inputs, exp_outputs.reshape(-1, 1)))
             cache_data = pd.DataFrame(input_data,
                                       columns=["eventId", "meanId", "randomId",
-                                               "r", "phi", "z", "derRefMeanCorr"] +\
+                                               "r", "phi", "z", "derRefMeanCorrR"] +\
                                               fourier_names + fluc_corr_names)
             batch_file = "%s_%d.root" % (full_path, i)
             batch_file_names.append(batch_file)


### PR DESCRIPTION
Two minor changes:

1. Adding number of Fourier coefficients used for prediction (`n_fourier_coeffs_apply`) to nd validation file name 
2. Fixing name of derivative (`derRefMeanCorrR`) in cached training data.