### PR TITLE
Adding data to cached training trees and user option to define number of IDCs for FFT

### DIFF
--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -56,6 +56,7 @@ class CommonSettings:
         self.dim_input = sum(self.opt_train)
         self.dim_output = sum(self.opt_predout)
 
+        self.num_fft_idcs = data_param["num_fft_idcs"]
         self.num_fourier_coeffs_train = data_param["num_fourier_coeffs_train"]
         self.num_fourier_coeffs_apply = data_param["num_fourier_coeffs_apply"]
 

--- a/tpcwithdnn/common_settings.py
+++ b/tpcwithdnn/common_settings.py
@@ -59,10 +59,10 @@ class CommonSettings:
         self.num_fourier_coeffs_train = data_param["num_fourier_coeffs_train"]
         self.num_fourier_coeffs_apply = data_param["num_fourier_coeffs_apply"]
 
-        if self.dim_output > 1:
-            self.logger.fatal("YOU CAN PREDICT ONLY 1 DISTORTION. The sum of opt_predout == 1")
         self.logger.info("Inputs active for training: (SCMean, SCFluctuations)=(%d, %d)",
                          self.opt_train[0], self.opt_train[1])
+        self.logger.info("Outputs: (dR, dRPhi, dZ) = (%d, %d, %d)",
+                         self.opt_predout[0], self.opt_predout[1], self.opt_predout[2])
 
         # Directories
         self.dirmodel = data_param["dirmodel"]
@@ -268,8 +268,6 @@ class XGBoostSettings:
         if self.downsample:
             self.cache_suffix = "%s_dpoints%d" % \
                 (self.cache_suffix, self.downsample_npoints)
-        self.cache_suffix = "%s_ftrain%d" % \
-            (self.cache_suffix, self.num_fourier_coeffs_train)
 
         self.suffix = "phi%d_r%d_z%d_nest%d_depth%d_lr%.3f_tm-%s" % \
                 (self.grid_phi, self.grid_r, self.grid_z, self.params["n_estimators"],
@@ -284,6 +282,9 @@ class XGBoostSettings:
         self.suffix = "%s_a%.1f_l%.5f_scale%.1f_base%.2f" %\
                 (self.suffix, self.params["reg_alpha"], self.params["reg_lambda"],
                  self.params["scale_pos_weight"], self.params["base_score"])
+        self.suffix = "%s_derR%dRPhi%dZ%d" % \
+            (self.suffix, self.opt_usederivative[0],
+             self.opt_usederivative[1], self.opt_usederivative[2])
         self.suffix = "%s_pred_doR%d_dophi%d_doz%d" % \
                 (self.suffix, self.opt_predout[0], self.opt_predout[1], self.opt_predout[2])
         self.suffix = "%s_input_z%.1f-%.1f" % \

--- a/tpcwithdnn/config_model_parameters.yml
+++ b/tpcwithdnn/config_model_parameters.yml
@@ -29,6 +29,7 @@ common:
   range_rnd_index_nd_val: [0, 999] # min and max index of random SC configurations for nd validation
   range_mean_index: [0, 44] # min and max index of mean SC configurations
   rnd_augment: false # use rnd-rnd augmentation instead of rnd-mean. Only used for model training
+  num_fft_idcs: 200 # number of 1D IDC values used for FFT, should correspond to ion drift time
   num_fourier_coeffs_train: 40 # number of Fourier coefficients to take from the 1D IDC train input
   num_fourier_coeffs_apply: 40 # number of Fourier coefficients to take from the 1D IDC apply input
 

--- a/tpcwithdnn/data_loader.py
+++ b/tpcwithdnn/data_loader.py
@@ -13,7 +13,10 @@ from tpcwithdnn.logger import get_logger
 SCALES_CONST = [0, 3, -3, 6, -6] # Indices of constant scaling of the mean maps
 SCALES_LINEAR = [0, 3, -3] # Indices of linear scaling of the mean maps
 SCALES_PARABOLIC = [0, 3, -3] # Indices of parabolic scaling of the mean maps
+
 NELE_PER_ADC = 670 # A constant for charge-to-ADC (digitized value) normalization
+
+NUM_FOURIER_COEFFS_MAX = 40
 
 def get_mean_desc(mean_id):
     """
@@ -316,11 +319,6 @@ def load_data_oned_idc(config, dirinput, event_index, downsample, num_fourier_co
     :return: tuple of inputs and expected outputs
     :rtype: tuple
     """
-    dim_output = sum(config.opt_predout)
-    if dim_output > 1:
-        logger = get_logger()
-        logger.fatal("YOU CAN PREDICT ONLY 1 DISTORTION. The sum of opt_predout == 1")
-
     [vec_r_pos, vec_phi_pos, vec_z_pos,
      *_,
      vec_mean_corr_r, vec_random_corr_r,
@@ -348,12 +346,10 @@ def load_data_oned_idc(config, dirinput, event_index, downsample, num_fourier_co
     dft_coeffs = get_fourier_coeffs(vec_oned_idc_fluc, num_fourier_coeffs_train,
                                     num_fourier_coeffs_apply)
 
-    mat_fluc_corr = np.array((vec_random_corr_r - vec_mean_corr_r,
-                              vec_random_corr_phi - vec_mean_corr_phi,
-                              vec_random_corr_z - vec_mean_corr_z))
+    vec_fluc_corr_r = vec_random_corr_r - vec_mean_corr_r
+    vec_fluc_corr_phi = vec_random_corr_phi - vec_mean_corr_phi
+    vec_fluc_corr_z = vec_random_corr_z - vec_mean_corr_z
 
-    vec_exp_corr_fluc, =\
-        mat_to_vec(config.opt_predout, (mat_fluc_corr,))
     # TODO: this will not work properly if vec_exp_corr_fluc containes more than one
     # distortion direction
     vec_der_ref_mean_corr_r = mat_der_ref_mean_corr[0]
@@ -367,10 +363,12 @@ def load_data_oned_idc(config, dirinput, event_index, downsample, num_fourier_co
         vec_ref_mean_corr_r = vec_ref_mean_corr_r[chosen_points]
         vec_ref_mean_corr_phi = vec_ref_mean_corr_phi[chosen_points]
         vec_ref_mean_corr_z = vec_ref_mean_corr_z[chosen_points]
+        vec_fluc_corr_r = vec_fluc_corr_r[chosen_points]
+        vec_fluc_corr_phi = vec_fluc_corr_phi[chosen_points]
+        vec_fluc_corr_z = vec_fluc_corr_z[chosen_points]
         vec_der_ref_mean_corr_r = vec_der_ref_mean_corr_r[chosen_points]
         vec_der_ref_mean_corr_rphi = vec_der_ref_mean_corr_rphi[chosen_points]
         vec_der_ref_mean_corr_z = vec_der_ref_mean_corr_z[chosen_points]
-        vec_exp_corr_fluc = vec_exp_corr_fluc[chosen_points]
 
     mat_der_ref_mean_corr_sel = np.array([vec_der_ref_mean_corr_r,
                                           vec_der_ref_mean_corr_rphi,
@@ -379,12 +377,17 @@ def load_data_oned_idc(config, dirinput, event_index, downsample, num_fourier_co
     inputs = get_input_oned_idc_single_map(vec_r_pos, vec_phi_pos, vec_z_pos,
                                            mat_der_ref_mean_corr_sel, dft_coeffs)
 
+    mat_fluc_corr = np.array([vec_fluc_corr_r,
+                              vec_fluc_corr_phi,
+                              vec_fluc_corr_z])
+    mat_fluc_corr = np.dstack(mat_fluc_corr[np.array(config.opt_predout) > 0])[0]
+
     vec_ref_mean_zerod_idc = np.full(vec_ref_mean_corr_r.shape[0],
                                      num_ref_mean_zerod_idc.astype('float32'))
     mat_ref_mean_values = np.dstack(np.array([vec_ref_mean_corr_r, vec_ref_mean_corr_phi,
                                               vec_ref_mean_corr_z, vec_ref_mean_zerod_idc]))[0]
 
-    return inputs, vec_exp_corr_fluc, mat_ref_mean_values
+    return inputs, mat_fluc_corr, mat_ref_mean_values
 
 
 def load_data(dirinput, event_index, z_range):

--- a/tpcwithdnn/idc_data_validator.py
+++ b/tpcwithdnn/idc_data_validator.py
@@ -89,6 +89,7 @@ class IDCDataValidator:
         vec_fluc_oned_idc = vec_random_oned_idc - vec_mean_oned_idc
         num_fluc_zerod_idc = num_random_zerod_idc - num_mean_zerod_idc
         dft_coeffs = get_fourier_coeffs(vec_fluc_oned_idc,
+                                        self.config.num_fft_idcs,
                                         self.config.num_fourier_coeffs_train,
                                         self.config.num_fourier_coeffs_apply)
 
@@ -142,9 +143,9 @@ class IDCDataValidator:
         dir_name = "%s/%s/parts/%d" % (self.config.dirtree, self.config.suffix, irnd)
         if not os.path.isdir(dir_name):
             os.makedirs(dir_name)
-        tree_filename = "%s/validation_mean%.2f_nEv%d_fapply%d.root" \
+        tree_filename = "%s/validation_mean%.2f_nEv%d_fapply%d_nfftidcs%d.root" \
             % (dir_name, self.mean_factors[self.mean_ids.index(mean_id)], self.config.train_events,
-               self.config.num_fourier_coeffs_apply)
+               self.config.num_fourier_coeffs_apply, self.config.num_fft_idcs)
         pandas_to_tree(df_single_map, tree_filename, 'validation')
 
 
@@ -155,6 +156,9 @@ class IDCDataValidator:
         loaded_model = self.model.load_model()
         dir_name = "%s/%s" % (self.config.dirtree, self.config.suffix)
 
+        # TODO: parallelize mean_ids
+        # TODO: provide possibility for rnd-rnd augment and mix
+        # TODO: provide usage of cached data
         for mean_id in self.mean_ids:
             counter = 0
 

--- a/tpcwithdnn/steer_analysis.py
+++ b/tpcwithdnn/steer_analysis.py
@@ -180,6 +180,9 @@ def main():
                         help="Set the number of trees for xgboost models")
     parser.add_argument("--maxdepth", dest="max_depth", type=int, default=argparse.SUPPRESS,
                         help="Set maximum depth of trees for xgboost models")
+    parser.add_argument("--nfftidcs", dest="num_fft_idcs", type=int,
+                        default=argparse.SUPPRESS, help="Set number of 1D IDCs used for" \
+                        " the FFT. Corresponds to the ion drift time (ms) used in simulation.")
     parser.add_argument("--nfouriertrain", dest="num_fourier_coeffs_train", type=int,
                         default=argparse.SUPPRESS, help="Set number of Fourier coefficients" \
                         " to take from the 1D IDC train input")
@@ -224,6 +227,8 @@ def main():
         config_parameters["xgboost"]["params"]["n_estimators"] = args.n_estimators
     if "max_depth" in args:
         config_parameters["xgboost"]["params"]["max_depth"] = args.max_depth
+    if "num_fft_idcs" in args:
+        config_parameters["common"]["num_fft_idcs"] = args.num_fft_idcs
     if "num_fourier_coeffs_train" in args:
         config_parameters["common"]["num_fourier_coeffs_train"] = args.num_fourier_coeffs_train
     if "num_fourier_coeffs_apply" in args:

--- a/tpcwithdnn/xgboost_optimiser.py
+++ b/tpcwithdnn/xgboost_optimiser.py
@@ -191,7 +191,7 @@ class XGBoostOptimiser(Optimiser):
             inputs_single, exp_outputs_single, mean_values_single  = load_data_oned_idc(
                 self.config, dirinput,
                 indexev, downsample,
-                num_fourier_coeffs_train, num_fourier_coeffs_apply)
+                self.config.num_fft_idcs, num_fourier_coeffs_train, num_fourier_coeffs_apply)
             inputs.append(inputs_single)
             exp_outputs.append(exp_outputs_single)
             mean_values.append(mean_values_single)


### PR DESCRIPTION
1) Information added to cached training data:
- always ```NUM_FOURIER_COEFFS_MAX``` are stored
- corrections of fluctuations and derivatives dr, drphi, dz by user options ```opt_predout```, ```opt_usederivative```

2) Parameter to define number of 1D IDC values used in FFT for calculation of Fourier coefficients
- used to assume different ion drift times